### PR TITLE
Add DynamoDB Document API support for DynamoDB Streams

### DIFF
--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -62,6 +62,11 @@
       <artifactId>aws-java-sdk-dynamodb</artifactId>
       <version>[1.10.5,)</version>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-lambda-java-core</artifactId>
+      <version>[1.0.0,)</version>
+    </dependency>
   </dependencies>
   
   <profiles>

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/document/DynamodbDocumentEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/document/DynamodbDocumentEvent.java
@@ -1,0 +1,53 @@
+/* Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+package com.amazonaws.services.lambda.runtime.events.document;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
+
+/**
+ * Represents an Amazon DynamoDB event for use with the DynamoDB Document API.
+ */
+public class DynamodbDocumentEvent {
+    private List<DynamodbStreamItem> itemRecords;
+
+    private final DynamodbEvent event;
+
+    public DynamodbDocumentEvent(DynamodbEvent event) {
+        if (this.event == null)
+            throw new IllegalArgumentException("event must be specified");
+        this.event = event;
+    }
+
+    /**
+     * Gets the list of DynamoDB event records
+     *
+     */
+    public List<DynamodbStreamItem> getItemRecords() {
+        if (itemRecords == null) {
+            List<DynamodbStreamRecord> src = event.getRecords();
+            List<DynamodbStreamItem> dst = new ArrayList<DynamodbStreamItem>(
+                    src.size());
+
+            for (DynamodbStreamRecord r : src)
+                dst.add(new DynamodbStreamItem(r));
+            event.setRecords(null);
+            itemRecords = dst;
+        }
+
+        return itemRecords;
+    }
+
+    /**
+     * Sets the list of DynamoDB event records
+     *
+     * @param itemRecords
+     *            a list of DynamoDb event records
+     */
+    public void setItemRecords(List<DynamodbStreamItem> itemRecords) {
+        this.itemRecords = itemRecords;
+    }
+}

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/document/DynamodbEventHandler.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/document/DynamodbEventHandler.java
@@ -1,0 +1,29 @@
+package com.amazonaws.services.lambda.runtime.events.document;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+
+/**
+ *
+ * Dynamodb event handlers implement AWS Lambda Function application logic using
+ * plain old java objects as input and output.
+ *
+ * @param <O> The output parameter type
+ */
+public abstract class DynamodbEventHandler<O> implements RequestHandler<DynamodbEvent, O> {
+
+    /**
+     * Handles a Dynamodb event using the Document API
+     *
+     * @param input The DynamoDB document event
+     * @param context The Lambda execution environment context object.
+     * @return The Lambda Function output
+     */
+    public abstract O handleEvent(DynamodbDocumentEvent input, Context context);
+
+    @Override
+    public final O handleRequest(DynamodbEvent input, Context context) {
+        return handleEvent(new DynamodbDocumentEvent(input), context);
+    }
+}

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/document/DynamodbStreamItem.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/document/DynamodbStreamItem.java
@@ -1,0 +1,36 @@
+/* Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+package com.amazonaws.services.lambda.runtime.events.document;
+
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
+
+/**
+ * The unit of data of an Amazon DynamoDB event.
+ */
+public class DynamodbStreamItem extends ItemRecord {
+    private static final long serialVersionUID = 1L;
+    private final DynamodbStreamRecord record;
+
+    public DynamodbStreamItem(DynamodbStreamRecord record) {
+        super(record);
+        this.record = record;
+    }
+
+    /**
+     * Gets the event source arn of DynamoDB
+     *
+     */
+    public String getEventSourceARN() {
+        return record.getEventSourceARN();
+    }
+
+    /**
+     * Sets the event source arn of DynamoDB
+     *
+     * @param eventSourceArn
+     *            A string containing the event source arn
+     */
+    public void setEventSourceARN(String eventSourceARN) {
+        record.setEventSourceARN(eventSourceARN);
+    }
+}

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/document/ItemRecord.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/document/ItemRecord.java
@@ -1,0 +1,617 @@
+/*
+ * Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.lambda.runtime.events.document;
+
+import java.io.Serializable;
+
+import com.amazonaws.services.dynamodbv2.model.OperationType;
+import com.amazonaws.services.dynamodbv2.model.Record;
+
+/**
+ * <p>
+ * An item-centric description of an unique event within a stream.
+ * </p>
+ */
+public class ItemRecord implements Serializable, Cloneable {
+    private static final long serialVersionUID = 1L;
+    /**
+     * The low-level record on which this item record is built.
+     */
+    private final Record record;
+
+    /**
+     * <p>
+     * The main body of the stream item, containing all of the
+     * DynamoDB-specific fields.
+     * </p>
+     */
+    private StreamItem streamItem;
+
+    public ItemRecord(Record record) {
+        if (this.record == null)
+            throw new IllegalArgumentException("record must be specified");
+        this.record = record;
+    }
+
+    /**
+     * <p>
+     * A globally unique identifier for the event that was recorded in this
+     * stream record.
+     * </p>
+     *
+     * @param eventID
+     *        A globally unique identifier for the event that was recorded in
+     *        this stream record.
+     */
+    public void setEventID(String eventID) {
+        record.setEventID(eventID);
+    }
+
+    /**
+     * <p>
+     * A globally unique identifier for the event that was recorded in this
+     * stream record.
+     * </p>
+     *
+     * @return A globally unique identifier for the event that was recorded in
+     *         this stream record.
+     */
+    public String getEventID() {
+        return record.getEventID();
+    }
+
+    /**
+     * <p>
+     * A globally unique identifier for the event that was recorded in this
+     * stream record.
+     * </p>
+     *
+     * @param eventID
+     *        A globally unique identifier for the event that was recorded in
+     *        this stream record.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public ItemRecord withEventID(String eventID) {
+        setEventID(eventID);
+        return this;
+    }
+
+    /**
+     * <p>
+     * The type of data modification that was performed on the DynamoDB table:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * <code>INSERT</code> - a new item was added to the table.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>MODIFY</code> - one or more of the item's attributes were updated.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>REMOVE</code> - the item was deleted from the table
+     * </p>
+     * </li>
+     * </ul>
+     *
+     * @param eventName
+     *        The type of data modification that was performed on the DynamoDB
+     *        table:</p>
+     *        <ul>
+     *        <li>
+     *        <p>
+     *        <code>INSERT</code> - a new item was added to the table.
+     *        </p>
+     *        </li>
+     *        <li>
+     *        <p>
+     *        <code>MODIFY</code> - one or more of the item's attributes were
+     *        updated.
+     *        </p>
+     *        </li>
+     *        <li>
+     *        <p>
+     *        <code>REMOVE</code> - the item was deleted from the table
+     *        </p>
+     *        </li>
+     * @see OperationType
+     */
+    public void setEventName(String eventName) {
+        record.setEventName(eventName);
+    }
+
+    /**
+     * <p>
+     * The type of data modification that was performed on the DynamoDB table:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * <code>INSERT</code> - a new item was added to the table.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>MODIFY</code> - one or more of the item's attributes were updated.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>REMOVE</code> - the item was deleted from the table
+     * </p>
+     * </li>
+     * </ul>
+     *
+     * @return The type of data modification that was performed on the DynamoDB
+     *         table:</p>
+     *         <ul>
+     *         <li>
+     *         <p>
+     *         <code>INSERT</code> - a new item was added to the table.
+     *         </p>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         <code>MODIFY</code> - one or more of the item's attributes were
+     *         updated.
+     *         </p>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         <code>REMOVE</code> - the item was deleted from the table
+     *         </p>
+     *         </li>
+     * @see OperationType
+     */
+    public String getEventName() {
+        return record.getEventName();
+    }
+
+    /**
+     * <p>
+     * The type of data modification that was performed on the DynamoDB table:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * <code>INSERT</code> - a new item was added to the table.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>MODIFY</code> - one or more of the item's attributes were updated.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>REMOVE</code> - the item was deleted from the table
+     * </p>
+     * </li>
+     * </ul>
+     *
+     * @param eventName
+     *        The type of data modification that was performed on the DynamoDB
+     *        table:</p>
+     *        <ul>
+     *        <li>
+     *        <p>
+     *        <code>INSERT</code> - a new item was added to the table.
+     *        </p>
+     *        </li>
+     *        <li>
+     *        <p>
+     *        <code>MODIFY</code> - one or more of the item's attributes were
+     *        updated.
+     *        </p>
+     *        </li>
+     *        <li>
+     *        <p>
+     *        <code>REMOVE</code> - the item was deleted from the table
+     *        </p>
+     *        </li>
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     * @see OperationType
+     */
+    public ItemRecord withEventName(String eventName) {
+        setEventName(eventName);
+        return this;
+    }
+
+    /**
+     * <p>
+     * The type of data modification that was performed on the DynamoDB table:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * <code>INSERT</code> - a new item was added to the table.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>MODIFY</code> - one or more of the item's attributes were updated.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>REMOVE</code> - the item was deleted from the table
+     * </p>
+     * </li>
+     * </ul>
+     *
+     * @param eventName
+     *        The type of data modification that was performed on the DynamoDB
+     *        table:</p>
+     *        <ul>
+     *        <li>
+     *        <p>
+     *        <code>INSERT</code> - a new item was added to the table.
+     *        </p>
+     *        </li>
+     *        <li>
+     *        <p>
+     *        <code>MODIFY</code> - one or more of the item's attributes were
+     *        updated.
+     *        </p>
+     *        </li>
+     *        <li>
+     *        <p>
+     *        <code>REMOVE</code> - the item was deleted from the table
+     *        </p>
+     *        </li>
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     * @see OperationType
+     */
+    public void setEventName(OperationType eventName) {
+        record.setEventName(eventName);
+    }
+
+    /**
+     * <p>
+     * The type of data modification that was performed on the DynamoDB table:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * <code>INSERT</code> - a new item was added to the table.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>MODIFY</code> - one or more of the item's attributes were updated.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>REMOVE</code> - the item was deleted from the table
+     * </p>
+     * </li>
+     * </ul>
+     *
+     * @param eventName
+     *        The type of data modification that was performed on the DynamoDB
+     *        table:</p>
+     *        <ul>
+     *        <li>
+     *        <p>
+     *        <code>INSERT</code> - a new item was added to the table.
+     *        </p>
+     *        </li>
+     *        <li>
+     *        <p>
+     *        <code>MODIFY</code> - one or more of the item's attributes were
+     *        updated.
+     *        </p>
+     *        </li>
+     *        <li>
+     *        <p>
+     *        <code>REMOVE</code> - the item was deleted from the table
+     *        </p>
+     *        </li>
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     * @see OperationType
+     */
+    public ItemRecord withEventName(OperationType eventName) {
+        setEventName(eventName);
+        return this;
+    }
+
+    /**
+     * <p>
+     * The version number of the stream record format. Currently, this is
+     * <i>1.0</i>.
+     * </p>
+     *
+     * @param eventVersion
+     *        The version number of the stream record format. Currently, this is
+     *        <i>1.0</i>.
+     */
+    public void setEventVersion(String eventVersion) {
+        record.setEventVersion(eventVersion);
+    }
+
+    /**
+     * <p>
+     * The version number of the stream record format. Currently, this is
+     * <i>1.0</i>.
+     * </p>
+     *
+     * @return The version number of the stream record format. Currently, this
+     *         is <i>1.0</i>.
+     */
+    public String getEventVersion() {
+        return record.getEventVersion();
+    }
+
+    /**
+     * <p>
+     * The version number of the stream record format. Currently, this is
+     * <i>1.0</i>.
+     * </p>
+     *
+     * @param eventVersion
+     *        The version number of the stream record format. Currently, this is
+     *        <i>1.0</i>.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public ItemRecord withEventVersion(String eventVersion) {
+        setEventVersion(eventVersion);
+        return this;
+    }
+
+    /**
+     * <p>
+     * The AWS service from which the stream record originated. For DynamoDB
+     * Streams, this is <i>aws:dynamodb</i>.
+     * </p>
+     *
+     * @param eventSource
+     *        The AWS service from which the stream record originated. For
+     *        DynamoDB Streams, this is <i>aws:dynamodb</i>.
+     */
+    public void setEventSource(String eventSource) {
+        record.setEventSource(eventSource);
+    }
+
+    /**
+     * <p>
+     * The AWS service from which the stream record originated. For DynamoDB
+     * Streams, this is <i>aws:dynamodb</i>.
+     * </p>
+     *
+     * @return The AWS service from which the stream record originated. For
+     *         DynamoDB Streams, this is <i>aws:dynamodb</i>.
+     */
+    public String getEventSource() {
+        return record.getEventSource();
+    }
+
+    /**
+     * <p>
+     * The AWS service from which the stream record originated. For DynamoDB
+     * Streams, this is <i>aws:dynamodb</i>.
+     * </p>
+     *
+     * @param eventSource
+     *        The AWS service from which the stream record originated. For
+     *        DynamoDB Streams, this is <i>aws:dynamodb</i>.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public ItemRecord withEventSource(String eventSource) {
+        setEventSource(eventSource);
+        return this;
+    }
+
+    /**
+     * <p>
+     * The region in which the <i>GetRecords</i> request was received.
+     * </p>
+     *
+     * @param awsRegion
+     *        The region in which the <i>GetRecords</i> request was received.
+     */
+    public void setAwsRegion(String awsRegion) {
+        record.setAwsRegion(awsRegion);
+    }
+
+    /**
+     * <p>
+     * The region in which the <i>GetRecords</i> request was received.
+     * </p>
+     *
+     * @return The region in which the <i>GetRecords</i> request was received.
+     */
+    public String getAwsRegion() {
+        return record.getAwsRegion();
+    }
+
+    /**
+     * <p>
+     * The region in which the <i>GetRecords</i> request was received.
+     * </p>
+     *
+     * @param awsRegion
+     *        The region in which the <i>GetRecords</i> request was received.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public ItemRecord withAwsRegion(String awsRegion) {
+        setAwsRegion(awsRegion);
+        return this;
+    }
+
+    /**
+     * <p>
+     * The main body of the stream item, containing all of the
+     * DynamoDB-specific fields.
+     * </p>
+     *
+     * @param streamItem
+     *        The main body of the stream item, containing all of the
+     *        DynamoDB-specific fields.
+     */
+    public void setStreamItem(StreamItem streamItem) {
+        this.streamItem = streamItem;
+        this.record.setDynamodb(null);
+    }
+
+    /**
+     * <p>
+     * The main body of the stream item, containing all of the
+     * DynamoDB-specific fields.
+     * </p>
+     *
+     * @return The main body of the stream item, containing all of the
+     *         DynamoDB-specific fields.
+     */
+    public StreamItem getStreamItem() {
+        if (streamItem == null)
+            streamItem = new StreamItem(record.getDynamodb());
+        return streamItem;
+    }
+
+    /**
+     * <p>
+     * The main body of the stream item, containing all of the
+     * DynamoDB-specific fields.
+     * </p>
+     *
+     * @param dynamodb
+     *        The main body of the stream item, containing all of the
+     *        DynamoDB-specific fields.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public ItemRecord withStreamItem(StreamItem streamItem) {
+        setStreamItem(streamItem);
+        return this;
+    }
+
+    /**
+     * Returns a string representation of this object; useful for testing and
+     * debugging.
+     *
+     * @return A string representation of this object.
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        if (getEventID() != null)
+            sb.append("EventID: " + getEventID() + ",");
+        if (getEventName() != null)
+            sb.append("EventName: " + getEventName() + ",");
+        if (getEventVersion() != null)
+            sb.append("EventVersion: " + getEventVersion() + ",");
+        if (getEventSource() != null)
+            sb.append("EventSource: " + getEventSource() + ",");
+        if (getAwsRegion() != null)
+            sb.append("AwsRegion: " + getAwsRegion() + ",");
+        if (getStreamItem() != null)
+            sb.append("StreamItem: " + getStreamItem());
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+
+        if (obj instanceof ItemRecord == false)
+            return false;
+        ItemRecord other = (ItemRecord) obj;
+        if (other.getEventID() == null ^ this.getEventID() == null)
+            return false;
+        if (other.getEventID() != null
+                && other.getEventID().equals(this.getEventID()) == false)
+            return false;
+        if (other.getEventName() == null ^ this.getEventName() == null)
+            return false;
+        if (other.getEventName() != null
+                && other.getEventName().equals(this.getEventName()) == false)
+            return false;
+        if (other.getEventVersion() == null ^ this.getEventVersion() == null)
+            return false;
+        if (other.getEventVersion() != null
+                && other.getEventVersion().equals(this.getEventVersion()) == false)
+            return false;
+        if (other.getEventSource() == null ^ this.getEventSource() == null)
+            return false;
+        if (other.getEventSource() != null
+                && other.getEventSource().equals(this.getEventSource()) == false)
+            return false;
+        if (other.getAwsRegion() == null ^ this.getAwsRegion() == null)
+            return false;
+        if (other.getAwsRegion() != null
+                && other.getAwsRegion().equals(this.getAwsRegion()) == false)
+            return false;
+        if (other.getStreamItem() == null ^ this.getStreamItem() == null)
+            return false;
+        if (other.getStreamItem() != null
+                && other.getStreamItem().equals(this.getStreamItem()) == false)
+            return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int hashCode = 1;
+
+        hashCode = prime * hashCode
+                + ((getEventID() == null) ? 0 : getEventID().hashCode());
+        hashCode = prime * hashCode
+                + ((getEventName() == null) ? 0 : getEventName().hashCode());
+        hashCode = prime
+                * hashCode
+                + ((getEventVersion() == null) ? 0 : getEventVersion()
+                        .hashCode());
+        hashCode = prime
+                * hashCode
+                + ((getEventSource() == null) ? 0 : getEventSource().hashCode());
+        hashCode = prime * hashCode
+                + ((getAwsRegion() == null) ? 0 : getAwsRegion().hashCode());
+        hashCode = prime * hashCode
+                + ((getStreamItem() == null) ? 0 : getStreamItem().hashCode());
+        return hashCode;
+    }
+
+    @Override
+    public ItemRecord clone() {
+        try {
+            return (ItemRecord) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new IllegalStateException(
+                    "Got a CloneNotSupportedException from Object.clone() "
+                            + "even though we're Cloneable!", e);
+        }
+    }
+}

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/document/StreamItem.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/document/StreamItem.java
@@ -1,0 +1,775 @@
+/*
+ * Copyright 2010-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.lambda.runtime.events.document;
+
+import static com.amazonaws.services.dynamodbv2.document.internal.InternalUtils.toSimpleMapValue;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.KeyAttribute;
+import com.amazonaws.services.dynamodbv2.document.PrimaryKey;
+import com.amazonaws.services.dynamodbv2.model.StreamRecord;
+import com.amazonaws.services.dynamodbv2.model.StreamViewType;
+
+/**
+ * <p>
+ * An item-centric description of a single data modification that was performed
+ * on an item in a DynamoDB table using the DynamoDB Document API.
+ * </p>
+ */
+public class StreamItem implements Serializable, Cloneable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The underlying low-level stream record on which this stream item is
+     * built.
+     */
+    private final StreamRecord record;
+
+    /**
+     * Internal cache to provide the behavior of access by reference instead of
+     * by value.
+     */
+    private PrimaryKey primaryKey;
+    private Item newImage;
+    private Item oldImage;
+
+    public StreamItem(StreamRecord record) {
+        this.record = record == null ? new StreamRecord() : record;
+    }
+
+    public StreamItem() {
+        this(new StreamRecord()); // a placeholder
+    }
+
+    /**
+     * <p>
+     * The primary key(s) for the DynamoDB item that was modified.
+     * </p>
+     *
+     * @return The primary key(s) for the DynamoDB item that was modified.
+     */
+    public PrimaryKey getPrimaryKey() {
+        if (primaryKey == null) {
+            Map<String, Object> keys = toSimpleMapValue(record.getKeys());
+            List<KeyAttribute> keyList = new LinkedList<KeyAttribute>();
+            for (Map.Entry<String, Object> e : keys.entrySet())
+                keyList.add(new KeyAttribute(e.getKey(), e.getValue()));
+            KeyAttribute[] components = keyList
+                    .toArray(new KeyAttribute[keyList.size()]);
+            primaryKey = new PrimaryKey(components);
+            record.clearKeysEntries();
+        }
+        return primaryKey;
+    }
+
+    /**
+     * <p>
+     * The primary key(s) for the DynamoDB item that was modified.
+     * </p>
+     *
+     * @param primaryKey
+     *            The primary key(s) for the DynamoDB item that was
+     *            modified.
+     */
+    public void setPrimaryKey(PrimaryKey primaryKey) {
+        this.primaryKey = primaryKey;
+        record.clearKeysEntries();
+    }
+
+    /**
+     * <p>
+     * The primary key(s) for the DynamoDB item that was modified.
+     * </p>
+     *
+     * @param primaryKey
+     *            The primary key(s) for the DynamoDB item that was modified.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public StreamItem withPrimaryKey(PrimaryKey primaryKey) {
+        setPrimaryKey(primaryKey);
+        return this;
+    }
+
+    public StreamItem addKeysEntry(String attrName, Object value) {
+        PrimaryKey pk = this.getPrimaryKey();
+        if (pk.hasComponent(attrName))
+            throw new IllegalArgumentException("Duplicated keys (" + attrName
+                    + ") are provided.");
+        pk.addComponent(attrName, value);
+        return this;
+    }
+
+    /**
+     * Removes all the entries added into Keys. &lt;p> Returns a reference to
+     * this object so that method calls can be chained together.
+     */
+    public StreamItem clearKeysEntries() {
+        this.primaryKey = null;
+        record.clearKeysEntries();
+        return this;
+    }
+
+    /**
+     * <p>
+     * The item in the DynamoDB table as it appeared after it was modified.
+     * </p>
+     *
+     * @return The item in the DynamoDB table as it appeared after it was
+     *         modified.
+     */
+    public Item getNewImage() {
+        if (newImage == null) {
+            newImage = Item.fromMap(toSimpleMapValue(record.getNewImage()));
+            record.clearNewImageEntries();
+        }
+        return newImage;
+    }
+
+    /**
+     * <p>
+     * The item in the DynamoDB table as it appeared after it was modified.
+     * </p>
+     *
+     * @param newImage
+     *            The item in the DynamoDB table as it appeared after it was
+     *            modified.
+     */
+    public void setNewImage(Item newImage) {
+        this.newImage = newImage;
+        record.clearNewImageEntries();
+    }
+
+    /**
+     * <p>
+     * The item in the DynamoDB table as it appeared after it was modified.
+     * </p>
+     *
+     * @param newImage
+     *            The item in the DynamoDB table as it appeared after it was
+     *            modified.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public StreamItem withNewImage(Item newImage) {
+        setNewImage(newImage);
+        return this;
+    }
+
+    public StreamItem addNewImageEntry(String key, Object value) {
+        Item newImage = this.getNewImage();
+        if (newImage.hasAttribute(key))
+            throw new IllegalArgumentException("Duplicated keys (" + key
+                    + ") are provided.");
+        newImage.with(key, value);
+        return this;
+    }
+
+    /**
+     * Removes all the entries added into NewImage. &lt;p> Returns a reference
+     * to this object so that method calls can be chained together.
+     */
+    public StreamItem clearNewImageEntries() {
+        this.newImage = null;
+        record.clearNewImageEntries();
+        return this;
+    }
+
+    /**
+     * <p>
+     * The item in the DynamoDB table as it appeared before it was modified.
+     * </p>
+     *
+     * @return The item in the DynamoDB table as it appeared before it was
+     *         modified.
+     */
+    public Item getOldImage() {
+        if (oldImage == null) {
+            oldImage = Item.fromMap(toSimpleMapValue(record.getOldImage()));
+            record.clearOldImageEntries();
+        }
+        return oldImage;
+    }
+
+    /**
+     * <p>
+     * The item in the DynamoDB table as it appeared before it was modified.
+     * </p>
+     *
+     * @param oldImage
+     *            The item in the DynamoDB table as it appeared before it was
+     *            modified.
+     */
+    public void setOldImage(Item oldImage) {
+        this.oldImage = oldImage;
+        record.clearOldImageEntries();
+    }
+
+    /**
+     * <p>
+     * The item in the DynamoDB table as it appeared before it was modified.
+     * </p>
+     *
+     * @param oldImage
+     *            The item in the DynamoDB table as it appeared before it was
+     *            modified.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public StreamItem withOldImage(Item oldImage) {
+        setOldImage(oldImage);
+        return this;
+    }
+
+    public StreamItem addOldImageEntry(String key, Object value) {
+        Item oldImage = this.getOldImage();
+        if (oldImage.hasAttribute(key))
+            throw new IllegalArgumentException("Duplicated keys (" + key
+                    + ") are provided.");
+        oldImage.with(key, value);
+        return this;
+    }
+
+    /**
+     * Removes all the entries added into OldImage. &lt;p> Returns a reference
+     * to this object so that method calls can be chained together.
+     */
+    public StreamItem clearOldImageEntries() {
+        this.oldImage = null;
+        return this;
+    }
+
+    /**
+     * <p>
+     * The sequence number of the stream record.
+     * </p>
+     *
+     * @param sequenceNumber
+     *            The sequence number of the stream record.
+     */
+    public void setSequenceNumber(String sequenceNumber) {
+        record.setSequenceNumber(sequenceNumber);
+    }
+
+    /**
+     * <p>
+     * The sequence number of the stream record.
+     * </p>
+     *
+     * @return The sequence number of the stream record.
+     */
+    public String getSequenceNumber() {
+        return record.getSequenceNumber();
+    }
+
+    /**
+     * <p>
+     * The sequence number of the stream record.
+     * </p>
+     *
+     * @param sequenceNumber
+     *            The sequence number of the stream record.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public StreamItem withSequenceNumber(String sequenceNumber) {
+        setSequenceNumber(sequenceNumber);
+        return this;
+    }
+
+    /**
+     * <p>
+     * The size of the stream record, in bytes.
+     * </p>
+     *
+     * @param sizeBytes
+     *            The size of the stream record, in bytes.
+     */
+    public void setSizeBytes(Long sizeBytes) {
+        record.setSizeBytes(sizeBytes);
+    }
+
+    /**
+     * <p>
+     * The size of the stream record, in bytes.
+     * </p>
+     *
+     * @return The size of the stream record, in bytes.
+     */
+    public Long getSizeBytes() {
+        return record.getSizeBytes();
+    }
+
+    /**
+     * <p>
+     * The size of the stream record, in bytes.
+     * </p>
+     *
+     * @param sizeBytes
+     *            The size of the stream record, in bytes.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public StreamItem withSizeBytes(Long sizeBytes) {
+        setSizeBytes(sizeBytes);
+        return this;
+    }
+
+    /**
+     * <p>
+     * The type of data from the modified DynamoDB item that was captured in
+     * this stream record:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * <code>KEYS_ONLY</code> - only the key attributes of the modified item.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>NEW_IMAGE</code> - the entire item, as it appears after it was
+     * modified.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>OLD_IMAGE</code> - the entire item, as it appeared before it was
+     * modified.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>NEW_AND_OLD_IMAGES</code> — both the new and the old item images of
+     * the item.
+     * </p>
+     * </li>
+     * </ul>
+     *
+     * @param streamViewType
+     *            The type of data from the modified DynamoDB item that was
+     *            captured in this stream record:</p>
+     *            <ul>
+     *            <li>
+     *            <p>
+     *            <code>KEYS_ONLY</code> - only the key attributes of the
+     *            modified item.
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            <code>NEW_IMAGE</code> - the entire item, as it appears after
+     *            it was modified.
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            <code>OLD_IMAGE</code> - the entire item, as it appeared
+     *            before it was modified.
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            <code>NEW_AND_OLD_IMAGES</code> — both the new and the old
+     *            item images of the item.
+     *            </p>
+     *            </li>
+     * @see StreamViewType
+     */
+    public void setStreamViewType(String streamViewType) {
+        record.setStreamViewType(streamViewType);
+    }
+
+    /**
+     * <p>
+     * The type of data from the modified DynamoDB item that was captured in
+     * this stream record:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * <code>KEYS_ONLY</code> - only the key attributes of the modified item.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>NEW_IMAGE</code> - the entire item, as it appears after it was
+     * modified.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>OLD_IMAGE</code> - the entire item, as it appeared before it was
+     * modified.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>NEW_AND_OLD_IMAGES</code> — both the new and the old item images of
+     * the item.
+     * </p>
+     * </li>
+     * </ul>
+     *
+     * @return The type of data from the modified DynamoDB item that was
+     *         captured in this stream record:</p>
+     *         <ul>
+     *         <li>
+     *         <p>
+     *         <code>KEYS_ONLY</code> - only the key attributes of the modified
+     *         item.
+     *         </p>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         <code>NEW_IMAGE</code> - the entire item, as it appears after it
+     *         was modified.
+     *         </p>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         <code>OLD_IMAGE</code> - the entire item, as it appeared before
+     *         it was modified.
+     *         </p>
+     *         </li>
+     *         <li>
+     *         <p>
+     *         <code>NEW_AND_OLD_IMAGES</code> — both the new and the old item
+     *         images of the item.
+     *         </p>
+     *         </li>
+     * @see StreamViewType
+     */
+    public String getStreamViewType() {
+        return record.getStreamViewType();
+    }
+
+    /**
+     * <p>
+     * The type of data from the modified DynamoDB item that was captured in
+     * this stream record:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * <code>KEYS_ONLY</code> - only the key attributes of the modified item.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>NEW_IMAGE</code> - the entire item, as it appears after it was
+     * modified.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>OLD_IMAGE</code> - the entire item, as it appeared before it was
+     * modified.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>NEW_AND_OLD_IMAGES</code> — both the new and the old item images of
+     * the item.
+     * </p>
+     * </li>
+     * </ul>
+     *
+     * @param streamViewType
+     *            The type of data from the modified DynamoDB item that was
+     *            captured in this stream record:</p>
+     *            <ul>
+     *            <li>
+     *            <p>
+     *            <code>KEYS_ONLY</code> - only the key attributes of the
+     *            modified item.
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            <code>NEW_IMAGE</code> - the entire item, as it appears after
+     *            it was modified.
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            <code>OLD_IMAGE</code> - the entire item, as it appeared
+     *            before it was modified.
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            <code>NEW_AND_OLD_IMAGES</code> — both the new and the old
+     *            item images of the item.
+     *            </p>
+     *            </li>
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     * @see StreamViewType
+     */
+    public StreamItem withStreamViewType(String streamViewType) {
+        setStreamViewType(streamViewType);
+        return this;
+    }
+
+    /**
+     * <p>
+     * The type of data from the modified DynamoDB item that was captured in
+     * this stream record:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * <code>KEYS_ONLY</code> - only the key attributes of the modified item.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>NEW_IMAGE</code> - the entire item, as it appears after it was
+     * modified.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>OLD_IMAGE</code> - the entire item, as it appeared before it was
+     * modified.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>NEW_AND_OLD_IMAGES</code> — both the new and the old item images of
+     * the item.
+     * </p>
+     * </li>
+     * </ul>
+     *
+     * @param streamViewType
+     *            The type of data from the modified DynamoDB item that was
+     *            captured in this stream record:</p>
+     *            <ul>
+     *            <li>
+     *            <p>
+     *            <code>KEYS_ONLY</code> - only the key attributes of the
+     *            modified item.
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            <code>NEW_IMAGE</code> - the entire item, as it appears after
+     *            it was modified.
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            <code>OLD_IMAGE</code> - the entire item, as it appeared
+     *            before it was modified.
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            <code>NEW_AND_OLD_IMAGES</code> — both the new and the old
+     *            item images of the item.
+     *            </p>
+     *            </li>
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     * @see StreamViewType
+     */
+    public void setStreamViewType(StreamViewType streamViewType) {
+        record.setStreamViewType(streamViewType);
+    }
+
+    /**
+     * <p>
+     * The type of data from the modified DynamoDB item that was captured in
+     * this stream record:
+     * </p>
+     * <ul>
+     * <li>
+     * <p>
+     * <code>KEYS_ONLY</code> - only the key attributes of the modified item.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>NEW_IMAGE</code> - the entire item, as it appears after it was
+     * modified.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>OLD_IMAGE</code> - the entire item, as it appeared before it was
+     * modified.
+     * </p>
+     * </li>
+     * <li>
+     * <p>
+     * <code>NEW_AND_OLD_IMAGES</code> — both the new and the old item images of
+     * the item.
+     * </p>
+     * </li>
+     * </ul>
+     *
+     * @param streamViewType
+     *            The type of data from the modified DynamoDB item that was
+     *            captured in this stream record:</p>
+     *            <ul>
+     *            <li>
+     *            <p>
+     *            <code>KEYS_ONLY</code> - only the key attributes of the
+     *            modified item.
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            <code>NEW_IMAGE</code> - the entire item, as it appears after
+     *            it was modified.
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            <code>OLD_IMAGE</code> - the entire item, as it appeared
+     *            before it was modified.
+     *            </p>
+     *            </li>
+     *            <li>
+     *            <p>
+     *            <code>NEW_AND_OLD_IMAGES</code> — both the new and the old
+     *            item images of the item.
+     *            </p>
+     *            </li>
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     * @see StreamViewType
+     */
+    public StreamItem withStreamViewType(StreamViewType streamViewType) {
+        setStreamViewType(streamViewType);
+        return this;
+    }
+
+    /**
+     * Returns a string representation of this object; useful for testing and
+     * debugging.
+     *
+     * @return A string representation of this object.
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        if (getPrimaryKey() != null)
+            sb.append("Keys: " + getPrimaryKey() + ",");
+        if (getNewImage() != null)
+            sb.append("NewImage: " + getNewImage() + ",");
+        if (getOldImage() != null)
+            sb.append("OldImage: " + getOldImage() + ",");
+        if (getSequenceNumber() != null)
+            sb.append("SequenceNumber: " + getSequenceNumber() + ",");
+        if (getSizeBytes() != null)
+            sb.append("SizeBytes: " + getSizeBytes() + ",");
+        if (getStreamViewType() != null)
+            sb.append("StreamViewType: " + getStreamViewType());
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+
+        if (obj instanceof StreamItem == false)
+            return false;
+        StreamItem other = (StreamItem) obj;
+        if (other.getPrimaryKey() == null ^ this.getPrimaryKey() == null)
+            return false;
+        if (other.getPrimaryKey() != null
+                && other.getPrimaryKey().equals(this.getPrimaryKey()) == false)
+            return false;
+        if (other.getNewImage() == null ^ this.getNewImage() == null)
+            return false;
+        if (other.getNewImage() != null
+                && other.getNewImage().equals(this.getNewImage()) == false)
+            return false;
+        if (other.getOldImage() == null ^ this.getOldImage() == null)
+            return false;
+        if (other.getOldImage() != null
+                && other.getOldImage().equals(this.getOldImage()) == false)
+            return false;
+        if (other.getSequenceNumber() == null
+                ^ this.getSequenceNumber() == null)
+            return false;
+        if (other.getSequenceNumber() != null
+                && other.getSequenceNumber().equals(this.getSequenceNumber()) == false)
+            return false;
+        if (other.getSizeBytes() == null ^ this.getSizeBytes() == null)
+            return false;
+        if (other.getSizeBytes() != null
+                && other.getSizeBytes().equals(this.getSizeBytes()) == false)
+            return false;
+        if (other.getStreamViewType() == null
+                ^ this.getStreamViewType() == null)
+            return false;
+        if (other.getStreamViewType() != null
+                && other.getStreamViewType().equals(this.getStreamViewType()) == false)
+            return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int hashCode = 1;
+
+        hashCode = prime * hashCode
+                + ((getPrimaryKey() == null) ? 0 : getPrimaryKey().hashCode());
+        hashCode = prime * hashCode
+                + ((getNewImage() == null) ? 0 : getNewImage().hashCode());
+        hashCode = prime * hashCode
+                + ((getOldImage() == null) ? 0 : getOldImage().hashCode());
+        hashCode = prime
+                * hashCode
+                + ((getSequenceNumber() == null) ? 0 : getSequenceNumber()
+                        .hashCode());
+        hashCode = prime * hashCode
+                + ((getSizeBytes() == null) ? 0 : getSizeBytes().hashCode());
+        hashCode = prime
+                * hashCode
+                + ((getStreamViewType() == null) ? 0 : getStreamViewType()
+                        .hashCode());
+        return hashCode;
+    }
+
+    @Override
+    public StreamItem clone() {
+        try {
+            return (StreamItem) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new IllegalStateException(
+                    "Got a CloneNotSupportedException from Object.clone() "
+                            + "even though we're Cloneable!", e);
+        }
+    }
+}


### PR DESCRIPTION
In summary, this is a proposed change to provide DynamoDB Document API support for DynamoDB Streams, so that Stream events can be processed at the Document API level, dealing with the high-level artifacts such as Item or PrimaryKey, instead of the low-level artifacts such as maps or AttributeValue.
