### PR TITLE
Update to use hard versions of dependencies

### DIFF
--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -3,7 +3,7 @@
   
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events Library</name>
@@ -40,22 +40,22 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>[1.10.5,)</version>
+      <version>1.10.64</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sns</artifactId>
-      <version>[1.10.5,)</version>
+      <version>1.10.64</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-cognitoidentity</artifactId>
-      <version>[1.10.5,)</version>
+      <version>1.10.64</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-kinesis</artifactId>
-      <version>[1.10.5,)</version>
+      <version>1.10.64</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-dynamodb</artifactId>
-      <version>[1.10.5,)</version>
+      <version>1.10.64</version>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
The open ended [1.10.5,) causes maven/ivy to go back to the central repo to look for the latest version every time the build runs.  At least in SBT, this forces the latest version of the SDK to download every time it is released, which has caused problems for our build.  It also makes dependency resolution take an unnecessarily long time.  This update chooses the current latest version of the SDK.