### PR TITLE
Added missing 'isBase64Encoded' field to APIGatewayProxyResponseEvent

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyResponseEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyResponseEvent.java
@@ -16,6 +16,8 @@ public class APIGatewayProxyResponseEvent implements Serializable, Cloneable {
     
     private String body;
 
+    private Boolean isBase64Encoded;
+
     /**
      * default constructor
      */
@@ -87,6 +89,29 @@ public class APIGatewayProxyResponseEvent implements Serializable, Cloneable {
      */
     public APIGatewayProxyResponseEvent withBody(String body) {
         this.setBody(body);
+        return this;
+    }
+
+    /**
+     * @return whether the body String is base64 encoded.
+     */
+    public Boolean getIsBase64Encoded() {
+        return this.isBase64Encoded;
+    }
+
+    /**
+     * @param isBase64Encoded Whether the body String is base64 encoded
+     */
+    public void setIsBase64Encoded(Boolean isBase64Encoded) {
+        this.isBase64Encoded = isBase64Encoded;
+    }
+
+    /**
+     * @param isBase64Encoded Whether the body String is base64 encoded
+     * @return APIGatewayProxyRequestEvent
+     */
+    public APIGatewayProxyResponseEvent withIsBase64Encoded(Boolean isBase64Encoded) {
+        this.setIsBase64Encoded(isBase64Encoded);
         return this;
     }
 


### PR DESCRIPTION
*Issue, if available:*  #46
*Description of changes:* Added missing 'isBase64Encoded' field to APIGatewayProxyResponseEvent.java

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
