### PR TITLE
Make SQSEvent.SQSMessage default ctor public

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SQSEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SQSEvent.java
@@ -227,7 +227,7 @@ public class SQSEvent implements Serializable, Cloneable {
         /**
          * Default constructor
          */
-        private SQSMessage() {}
+        public SQSMessage() {}
 
         /**
          * Gets the message id


### PR DESCRIPTION
The SQSEvent.SQSMessage class was recently made public but we need to make default constructor public as well

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
