### PR TITLE
Fix the packages directive in the example config

### DIFF
--- a/aws-lambda-java-log4j2/README.md
+++ b/aws-lambda-java-log4j2/README.md
@@ -68,7 +68,7 @@ Add the following file `<project-dir>/src/main/resources/log4j2.xml`
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration packages="com.amazonaws.services.lambda.runtime.log4j2.LambdaAppender">
+<Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
   <Appenders>
     <Lambda name="Lambda">
       <PatternLayout>


### PR DESCRIPTION
When using the config from the readme you get these errors:

```
Error processing element Lambda ([Appenders: null]): CLASS_NOT_FOUND
Unable to locate appender "lambda" for logger config "root"
```

*Description of changes:*

The Lambda documentation site (https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html) does not have the class name in the attribute, and removing the class name makes the errors above go away.