### PR TITLE
Adding default constructor for S3Event for easier deserialization

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/S3Event.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/S3Event.java
@@ -5,6 +5,7 @@ package com.amazonaws.services.lambda.runtime.events;
 import com.amazonaws.services.s3.event.S3EventNotification;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -14,6 +15,14 @@ import java.util.List;
 public class S3Event extends S3EventNotification implements Serializable, Cloneable {
 
     private static final long serialVersionUID = -8094860465750962044L;
+
+    /**
+     * default constructor
+     * (Not available in v1)
+     */
+    public S3Event() {
+        super(new ArrayList<S3EventNotificationRecord>());
+    }
 
     /**
      * Create a new instance of S3Event


### PR DESCRIPTION
Issue #, if available: No issue opened.

Description of changes: Adding a default constructor to the S3Event. The reason for doing this is that it already has another constructor (which gets a list of records), so when working with Jackson we might encounter some issues when trying to deserialize data into this type.
The reason for adding the empty constructor is similar to the one explained here: https://docs.aws.amazon.com/lambda/latest/dg/java-handler-io-type-pojo.html under "note". Also, every other event class has a default constructor.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
