### PR TITLE
GH-65 Fix "Paramters" typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Maven build
+target/
+
+# IDEA internal
+*.iml
+.idea

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
@@ -960,9 +960,17 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
      * @param queryStringParameters The query string parameters that were part of the request
      * @return APIGatewayProxyRequestEvent
      */
-    public APIGatewayProxyRequestEvent withQueryStringParamters(Map<String, String> queryStringParameters) {
+    public APIGatewayProxyRequestEvent withQueryStringParameters(Map<String, String> queryStringParameters) {
         this.setQueryStringParameters(queryStringParameters);
         return this;
+    }
+
+    /**
+     * @deprecated Because of typo in method's name, use {@link #withQueryStringParameters} instead.
+     */
+    @Deprecated
+    public APIGatewayProxyRequestEvent withQueryStringParamters(Map<String, String> queryStringParameters) {
+        return withQueryStringParameters(queryStringParameters);
     }
 
     /**
@@ -1003,12 +1011,20 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
     }
 
     /**
-     * @param pathParameters The path paramters that were part of the request
+     * @param pathParameters The path parameters that were part of the request
      * @return APIGatewayProxyRequestEvent object
      */
-    public APIGatewayProxyRequestEvent withPathParamters(Map<String, String> pathParameters) {
+    public APIGatewayProxyRequestEvent withPathParameters(Map<String, String> pathParameters) {
         this.setPathParameters(pathParameters);
         return this;
+    }
+
+    /**
+     * @deprecated Because of typo in method's name, use {@link #withPathParameters} instead.
+     */
+    @Deprecated
+    public APIGatewayProxyRequestEvent withPathParamters(Map<String, String> pathParameters) {
+        return withPathParameters(pathParameters);
     }
 
     /**

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ConfigEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ConfigEvent.java
@@ -114,7 +114,7 @@ public class ConfigEvent implements Serializable, Cloneable {
     }
 
     /**
-     * @param ruleParameters String with rule paramters
+     * @param ruleParameters String with rule parameters
      * @return ConfigEvent
      */
     public ConfigEvent withRuleParameters(String ruleParameters) {


### PR DESCRIPTION
*Issue #65*

Fixed a typo in method's naming, also did a search and fixed the same in a couple of comments.
**Warning:** as existing API methods are renamed, it's a breaking change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
