### PR TITLE
Changed version of aws-lambda-java-core to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-core</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
The README.md show version 1.1.0 but 1.2.0 is already available

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
