### PR TITLE
Feature/gh 72 remove joda time

### DIFF
--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -44,15 +44,16 @@
 
   <dependencies>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.6</version>
-    </dependency>
-    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
       <version>1.11.163</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>joda-time</groupId>
+          <artifactId>joda-time</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -29,6 +29,12 @@
     </developer>
   </developers>
 
+  <properties>
+    <java.version>1.8</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+  </properties>
+
   <distributionManagement>
     <repository>
       <id>sonatype-nexus-staging</id>

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package com.amazonaws.services.lambda.runtime.events;
 
 import java.io.Serializable;
@@ -1118,7 +1131,7 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
         this.setIsBase64Encoded(isBase64Encoded);
         return this;
     }
-    
+
     /**
      * Returns a string representation of this object; useful for testing and debugging.
      *

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyResponseEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyResponseEvent.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package com.amazonaws.services.lambda.runtime.events;
 
 import java.io.Serializable;
@@ -9,11 +22,11 @@ import java.util.Map;
 public class APIGatewayProxyResponseEvent implements Serializable, Cloneable {
 
     private static final long serialVersionUID = 2263167344670024172L;
-    
+
     private Integer statusCode;
 
     private Map<String, String> headers;
-    
+
     private String body;
 
     /**

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CloudFrontEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CloudFrontEvent.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package com.amazonaws.services.lambda.runtime.events;
 
 import java.io.Serializable;

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CloudWatchLogsEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CloudWatchLogsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CodeCommitEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CodeCommitEvent.java
@@ -1,8 +1,7 @@
 package com.amazonaws.services.lambda.runtime.events;
 
-import org.joda.time.DateTime;
-
 import java.io.Serializable;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
@@ -270,7 +269,7 @@ public class CodeCommitEvent implements Serializable, Cloneable {
 
         private String eventVersion;
 
-        private DateTime eventTime;
+        private ZonedDateTime eventTime;
 
         private String eventTriggerName;
 
@@ -346,14 +345,14 @@ public class CodeCommitEvent implements Serializable, Cloneable {
         /**
          * @return event timestamp
          */
-        public DateTime getEventTime() {
+        public ZonedDateTime getEventTime() {
             return this.eventTime;
         }
 
         /**
          * @param eventTime event timestamp
          */
-        public void setEventTime(DateTime eventTime) {
+        public void setEventTime(ZonedDateTime eventTime) {
             this.eventTime = eventTime;
         }
 
@@ -361,7 +360,7 @@ public class CodeCommitEvent implements Serializable, Cloneable {
          * @param eventTime event timestamp
          * @return Record
          */
-        public Record withEventTime(DateTime eventTime) {
+        public Record withEventTime(ZonedDateTime eventTime) {
             setEventTime(eventTime);
             return this;
         }

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CodeCommitEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CodeCommitEvent.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.amazonaws.services.lambda.runtime.events;
 
 import java.io.Serializable;

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CognitoEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CognitoEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ConfigEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ConfigEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -71,7 +71,7 @@ public class ConfigEvent implements Serializable, Cloneable {
         setVersion(version);
         return this;
     }
-    
+
     /**
      * Gets the JSON-encoded notification published by AWS Config.
      * 
@@ -96,7 +96,7 @@ public class ConfigEvent implements Serializable, Cloneable {
         setInvokingEvent(invokingEvent);
         return this;
     }
-    
+
     /**
      * Gets the JSON-encoded map containing the AWS Config rule parameters.
      * 
@@ -121,7 +121,7 @@ public class ConfigEvent implements Serializable, Cloneable {
         setRuleParameters(ruleParameters);
         return this;
     }
-    
+
     /**
      * Gets the token associated with the invocation of the AWS Config rule's Lambda function.
      * 
@@ -146,7 +146,7 @@ public class ConfigEvent implements Serializable, Cloneable {
         setResultToken(resultToken);
         return this;
     }
-    
+
     /**
      * Gets the ARN of the AWS Config rule that triggered the event.
      * 
@@ -171,7 +171,7 @@ public class ConfigEvent implements Serializable, Cloneable {
         setConfigRuleArn(configRuleArn);
         return this;
     }
-    
+
     /**
      * Gets the ID of the AWS Config rule that triggered the event.
      * 
@@ -196,7 +196,7 @@ public class ConfigEvent implements Serializable, Cloneable {
         setConfigRuleId(configRuleId);
         return this;
     }
-    
+
     /**
      * Gets the name of the AWS Config rule that triggered the event.
      * 
@@ -221,7 +221,7 @@ public class ConfigEvent implements Serializable, Cloneable {
         setConfigRuleName(configRuleName);
         return this;
     }
-    
+
     /**
      * Gets the account ID of the AWS Config rule that triggered the event.
      * 
@@ -246,7 +246,7 @@ public class ConfigEvent implements Serializable, Cloneable {
         setAccountId(accountId);
         return this;
     }
-    
+
     /**
      * Gets the ARN of the IAM role that is assigned to AWS Config.
      * 
@@ -271,7 +271,7 @@ public class ConfigEvent implements Serializable, Cloneable {
         setExecutionRoleArn(executionRoleArn);
         return this;
     }
-    
+
     /**
      * Whether the AWS resource to be evaluated has been removed from the AWS Config rule's scope.
      * 

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/DynamodbEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/DynamodbEvent.java
@@ -1,4 +1,15 @@
-/* Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+/*
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 
 package com.amazonaws.services.lambda.runtime.events;
 
@@ -212,5 +223,5 @@ public class DynamodbEvent implements Serializable, Cloneable {
             throw new IllegalStateException("Got a CloneNotSupportedException from Object.clone()", e);
         }
     }
-    
+
 }

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/IoTButtonEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/IoTButtonEvent.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package com.amazonaws.services.lambda.runtime.events;
 
 import java.io.Serializable;

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisAnalyticsFirehoseInputPreprocessingEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisAnalyticsFirehoseInputPreprocessingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -10,6 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
+
 package com.amazonaws.services.lambda.runtime.events;
 
 import java.io.Serializable;

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisAnalyticsInputPreprocessingResponse.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisAnalyticsInputPreprocessingResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisAnalyticsOutputDeliveryEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisAnalyticsOutputDeliveryEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -10,6 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
+
 package com.amazonaws.services.lambda.runtime.events;
 
 import java.io.Serializable;

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisAnalyticsOutputDeliveryResponse.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisAnalyticsOutputDeliveryResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -10,6 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
+
 package com.amazonaws.services.lambda.runtime.events;
 
 import java.io.Serializable;

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisAnalyticsStreamsInputPreprocessingEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisAnalyticsStreamsInputPreprocessingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -10,6 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
+
 package com.amazonaws.services.lambda.runtime.events;
 
 import java.io.Serializable;

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisEvent.java
@@ -1,4 +1,15 @@
-/* Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+/*
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 
 package com.amazonaws.services.lambda.runtime.events;
 import java.io.Serializable;
@@ -124,7 +135,7 @@ public class KinesisEvent implements Serializable, Cloneable {
             return (Record) super.clone();
         }
     }
-    
+
     /**
      * Kinesis event records provide contextual data about a Kinesis record
      *

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisFirehoseEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisFirehoseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/LexEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/LexEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/S3Event.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/S3Event.java
@@ -1,4 +1,15 @@
-/* Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+/*
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 
 package com.amazonaws.services.lambda.runtime.events;
 

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SNSEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SNSEvent.java
@@ -12,9 +12,8 @@
  */
 package com.amazonaws.services.lambda.runtime.events;
 
-import org.joda.time.DateTime;
-
 import java.io.Serializable;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -181,7 +180,7 @@ public class SNSEvent implements Serializable, Cloneable {
 
         private String signature;
 
-        private DateTime timestamp;
+        private ZonedDateTime timestamp;
 
         private String topicArn;
 
@@ -421,7 +420,7 @@ public class SNSEvent implements Serializable, Cloneable {
          * Gets the message time stamp
          * @return timestamp of sns message
          */
-        public DateTime getTimestamp() {
+        public ZonedDateTime getTimestamp() {
             return timestamp;
         }
 
@@ -429,7 +428,7 @@ public class SNSEvent implements Serializable, Cloneable {
          * Sets the message time stamp
          * @param timestamp A Date object representing the message time stamp
          */
-        public void setTimestamp(DateTime timestamp) {
+        public void setTimestamp(ZonedDateTime timestamp) {
             this.timestamp = timestamp;
         }
 
@@ -437,7 +436,7 @@ public class SNSEvent implements Serializable, Cloneable {
          * @param timestamp timestamp
          * @return SNS
          */
-        public SNS withTimestamp(DateTime timestamp) {
+        public SNS withTimestamp(ZonedDateTime timestamp) {
             setTimestamp(timestamp);
             return this;
         }

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SNSEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SNSEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -10,6 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
+
 package com.amazonaws.services.lambda.runtime.events;
 
 import java.io.Serializable;

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SQSEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SQSEvent.java
@@ -1,5 +1,14 @@
 /*
- * Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.amazonaws.services.lambda.runtime.events;

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ScheduledEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ScheduledEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -68,7 +68,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setAccount(account);
         return this;
     }
-    
+
     /**
      * @return the aws region
      */
@@ -91,7 +91,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setRegion(region);
         return this;
     }
-    
+
     /**
      * @return The details of the events (usually left blank)
      */
@@ -114,7 +114,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setDetail(detail);
         return this;
     }
-    
+
     /**
      * @return The details type - see cloud watch events for more info
      */
@@ -137,7 +137,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setDetailType(detailType);
         return this;
     }
-    
+
     /**
      * @return the soruce of the event
      */
@@ -160,7 +160,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setSource(source);
         return this;
     }
-    
+
     /**
      * @return the timestamp for when the event is scheduled
      */
@@ -183,7 +183,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setTime(time);
         return this;
     }
-    
+
     /**
      * @return the id of the event
      */
@@ -206,7 +206,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setId(id);
         return this;
     }
-    
+
     /**
      * @return the resources used by event
      */
@@ -330,5 +330,5 @@ public class ScheduledEvent implements Serializable, Cloneable {
             throw new IllegalStateException("Got a CloneNotSupportedException from Object.clone()", e);
         }
     }
-    
+
 }

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ScheduledEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ScheduledEvent.java
@@ -13,9 +13,8 @@
 
 package com.amazonaws.services.lambda.runtime.events;
 
-import org.joda.time.DateTime;
-
 import java.io.Serializable;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -38,7 +37,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
 
     private String id;
 
-    private DateTime time;
+    private ZonedDateTime time;
 
     private List<String> resources;
 
@@ -165,14 +164,14 @@ public class ScheduledEvent implements Serializable, Cloneable {
     /**
      * @return the timestamp for when the event is scheduled
      */
-    public DateTime getTime() {
+    public ZonedDateTime getTime() {
         return this.time;
     }
 
     /**
      * @param time the timestamp for when the event is scheduled
      */
-    public void setTime(DateTime time) {
+    public void setTime(ZonedDateTime time) {
         this.time = time;
     }
 
@@ -180,7 +179,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
      * @param time the timestamp for when the event is scheduled
      * @return ScheduledEvent
      */
-    public ScheduledEvent withTime(DateTime time) {
+    public ScheduledEvent withTime(ZonedDateTime time) {
         setTime(time);
         return this;
     }


### PR DESCRIPTION
*Issue #72*

*Description of changes:*
- require Java 8
- remove **joda-time** library dependency
- replace **org.joda.time.DateTime** with **java.time.ZonedDateTime**
- fix license headers and remove unnecessary spaces

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.