### PR TITLE
Adding authorizer field to collect context properties from authorizer

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
@@ -29,6 +29,8 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
 
     private Map<String, String> stageVariables;
 
+    private Map<String, String> authorizer;
+
     private ProxyRequestContext requestContext;
 
     private String body;
@@ -917,6 +919,14 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
     public APIGatewayProxyRequestEvent withHeaders(Map<String, String> headers) {
         this.setHeaders(headers);
         return this;
+    }
+
+    private Map<String, String> getAuthorizer() {
+        return authorizer;
+    }
+
+    private void setAuthorizer(final Map<String, String> authorizer) {
+        this.authorizer = authorizer;
     }
 
     /**

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
@@ -921,11 +921,11 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
         return this;
     }
 
-    private Map<String, String> getAuthorizer() {
+    public Map<String, String> getAuthorizer() {
         return authorizer;
     }
 
-    private void setAuthorizer(final Map<String, String> authorizer) {
+    public void setAuthorizer(final Map<String, String> authorizer) {
         this.authorizer = authorizer;
     }
 
@@ -1148,6 +1148,8 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
             sb.append("httpMethod: ").append(getHttpMethod()).append(",");
         if (getHeaders() != null)
             sb.append("headers: ").append(getHeaders().toString()).append(",");
+        if (getAuthorizer() != null)
+            sb.append("authorizer: ").append(getAuthorizer().toString()).append(",");
         if (getMultiValueHeaders() != null)
             sb.append("multiValueHeaders: ").append(getMultiValueHeaders().toString()).append(",");
         if (getQueryStringParameters() != null)

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
@@ -60,7 +60,7 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
 
         private String path;
 
-        private Map<String, String> authorizer;
+        private Map<String, Object> authorizer;
 
         /**
          * default constructor
@@ -90,11 +90,11 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
             return this;
         }
 
-        public Map<String, String> getAuthorizer() {
+        public Map<String, Object> getAuthorizer() {
             return authorizer;
         }
 
-        public void setAuthorizer(final Map<String, String> authorizer) {
+        public void setAuthorizer(final Map<String, Object> authorizer) {
             this.authorizer = authorizer;
         }
 

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
@@ -29,8 +29,6 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
 
     private Map<String, String> stageVariables;
 
-    private Map<String, String> authorizer;
-
     private ProxyRequestContext requestContext;
 
     private String body;
@@ -62,6 +60,8 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
 
         private String path;
 
+        private Map<String, String> authorizer;
+
         /**
          * default constructor
          */
@@ -88,6 +88,14 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
         public ProxyRequestContext withAccountId(String accountId) {
             this.setAccountId(accountId);
             return this;
+        }
+
+        public Map<String, String> getAuthorizer() {
+            return authorizer;
+        }
+
+        public void setAuthorizer(final Map<String, String> authorizer) {
+            this.authorizer = authorizer;
         }
 
         /**
@@ -302,7 +310,9 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
             if (getApiId() != null)
                 sb.append("apiId: ").append(getApiId()).append(",");
             if (getPath() != null)
-                sb.append("path: ").append(getPath());
+                sb.append("path: ").append(getPath()).append(",");
+            if (getAuthorizer() != null)
+                sb.append("authorizer: ").append(getAuthorizer().toString());
             sb.append("}");
             return sb.toString();
         }
@@ -353,6 +363,10 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
                 return false;
             if (other.getPath() != null && other.getPath().equals(this.getPath()) == false)
                 return false;
+            if (other.getAuthorizer() == null ^ this.getAuthorizer() == null)
+                return false;
+            if (other.getAuthorizer() != null && !other.getAuthorizer().equals(this.getAuthorizer()))
+                return false;
             return true;
         }
 
@@ -370,6 +384,7 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
             hashCode = prime * hashCode + ((getHttpMethod() == null) ? 0 : getHttpMethod().hashCode());
             hashCode = prime * hashCode + ((getApiId() == null) ? 0 : getApiId().hashCode());
             hashCode = prime * hashCode + ((getPath() == null) ? 0 : getPath().hashCode());
+            hashCode = prime * hashCode + ((getAuthorizer() == null) ? 0 : getAuthorizer().hashCode());
             return hashCode;
         }
 
@@ -921,14 +936,6 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
         return this;
     }
 
-    public Map<String, String> getAuthorizer() {
-        return authorizer;
-    }
-
-    public void setAuthorizer(final Map<String, String> authorizer) {
-        this.authorizer = authorizer;
-    }
-
     /**
      * @return The multi value headers sent with the request
      */
@@ -951,17 +958,7 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
         this.setMultiValueHeaders(multiValueHeaders);
         return this;
     }
-
-    /**
-     * @param authorizer The context properties sent with the request from Authorizer
-     * @return APIGatewayProxyRequestEvent object
-     */
-    public APIGatewayProxyRequestEvent withAuthorizer(Map<String, String> authorizer) {
-        this.setAuthorizer(authorizer);
-        return this;
-    }
-
-
+    
     /**
      * @return The query string parameters that were part of the request
      */
@@ -1158,8 +1155,6 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
             sb.append("httpMethod: ").append(getHttpMethod()).append(",");
         if (getHeaders() != null)
             sb.append("headers: ").append(getHeaders().toString()).append(",");
-        if (getAuthorizer() != null)
-            sb.append("authorizer: ").append(getAuthorizer().toString()).append(",");
         if (getMultiValueHeaders() != null)
             sb.append("multiValueHeaders: ").append(getMultiValueHeaders().toString()).append(",");
         if (getQueryStringParameters() != null)
@@ -1210,10 +1205,6 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
             return false;
         if (other.getMultiValueHeaders() != null && other.getMultiValueHeaders().equals(this.getMultiValueHeaders()) == false)
             return false;
-        if (other.getAuthorizer() == null ^ this.getAuthorizer() == null)
-            return false;
-        if (other.getAuthorizer() != null && !other.getAuthorizer().equals(this.getAuthorizer()))
-            return false;
         if (other.getQueryStringParameters() == null ^ this.getQueryStringParameters() == null)
             return false;
         if (other.getQueryStringParameters() != null && other.getQueryStringParameters().equals(this.getQueryStringParameters()) == false)
@@ -1262,7 +1253,6 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
         hashCode = prime * hashCode + ((getRequestContext() == null) ? 0 : getRequestContext().hashCode());
         hashCode = prime * hashCode + ((getBody() == null) ? 0 : getBody().hashCode());
         hashCode = prime * hashCode + ((getIsBase64Encoded() == null) ? 0 : getIsBase64Encoded().hashCode());
-        hashCode = prime * hashCode + ((getAuthorizer() == null) ? 0 : getAuthorizer().hashCode());
         return hashCode;
     }
 

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
@@ -953,6 +953,16 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
     }
 
     /**
+     * @param authorizer The context properties sent with the request from Authorizer
+     * @return APIGatewayProxyRequestEvent object
+     */
+    public APIGatewayProxyRequestEvent withAuthorizer(Map<String, String> authorizer) {
+        this.setAuthorizer(authorizer);
+        return this;
+    }
+
+
+    /**
      * @return The query string parameters that were part of the request
      */
     public Map<String, String> getQueryStringParameters() {
@@ -1200,6 +1210,10 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
             return false;
         if (other.getMultiValueHeaders() != null && other.getMultiValueHeaders().equals(this.getMultiValueHeaders()) == false)
             return false;
+        if (other.getAuthorizer() == null ^ this.getAuthorizer() == null)
+            return false;
+        if (other.getAuthorizer() != null && !other.getAuthorizer().equals(this.getAuthorizer()))
+            return false;
         if (other.getQueryStringParameters() == null ^ this.getQueryStringParameters() == null)
             return false;
         if (other.getQueryStringParameters() != null && other.getQueryStringParameters().equals(this.getQueryStringParameters()) == false)
@@ -1248,6 +1262,7 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
         hashCode = prime * hashCode + ((getRequestContext() == null) ? 0 : getRequestContext().hashCode());
         hashCode = prime * hashCode + ((getBody() == null) ? 0 : getBody().hashCode());
         hashCode = prime * hashCode + ((getIsBase64Encoded() == null) ? 0 : getIsBase64Encoded().hashCode());
+        hashCode = prime * hashCode + ((getAuthorizer() == null) ? 0 : getAuthorizer().hashCode());
         return hashCode;
     }
 


### PR DESCRIPTION
*Issue #, if available:*
Reopening: https://github.com/aws/aws-lambda-java-libs/pull/39

*Description of changes:*
Adding a map to hold context properties from authorizer. cc: @bmoffatt @oharaandrew314 @miere . This PR was originally submitted by @oharaandrew314 and got closed based on a review comment for using `String` key/values. All other collection fields in this class use `Map<String, String>`. Not sure why we need to worry about other types (non `String`) just for this. We could keep this in the short term until we find a long term solution. Libraries for rest of the programming languages like golang & .Net already support this. Thanks for your support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
