### PR TITLE
Add missing xml namespace declarations to POM files

### DIFF
--- a/aws-lambda-java-core/pom.xml
+++ b/aws-lambda-java-core/pom.xml
@@ -1,4 +1,6 @@
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   
   <groupId>com.amazonaws</groupId>

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -1,4 +1,6 @@
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.amazonaws</groupId>

--- a/aws-lambda-java-log4j/pom.xml
+++ b/aws-lambda-java-log4j/pom.xml
@@ -1,4 +1,6 @@
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.amazonaws</groupId>

--- a/aws-lambda-java-log4j2/pom.xml
+++ b/aws-lambda-java-log4j2/pom.xml
@@ -1,4 +1,6 @@
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Without these declarations, the XML file cannot be validated correctly.

See examples:

* <https://maven.apache.org/pom.html#Quick_Overview>
* <https://github.com/aws/aws-sdk-java-v2/blob/master/aws-sdk-java/pom.xml>

The tool I'm using actually tries to validate these before using them
(<https://tiny.amazon.com/ibdzmlln/paste> -- Amazon internal link), so
that's why I ran into issues. I'm assuming most tools don't have the
validation enabled, so this is why others haven't reported this before.

The same issue can be easily replicated by pasting the current POM
files in <https://www.w3schools.com/xml/xml_validator.asp> as well
as just trying to open them with Firefox.

(P.s: Hello there Lambda team! We recently met in your Dublin office!)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
