### PR TITLE
Update log4j-core and log4j-api to 2.13.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-log4j2</artifactId>
-  <version>1.1.1</version>
+  <version>1.2.0</version>
 </dependency>
 ```
 
@@ -54,7 +54,7 @@ ___
 'com.amazonaws:aws-lambda-java-core:1.2.1'
 'com.amazonaws:aws-lambda-java-events:2.2.8'
 'com.amazonaws:aws-lambda-java-log4j:1.0.1'
-'com.amazonaws:aws-lambda-java-log4j2:1.1.1'
+'com.amazonaws:aws-lambda-java-log4j2:1.2.0'
 ```
 
 [Leiningen](http://leiningen.org) and [Boot](http://boot-clj.com)
@@ -63,7 +63,7 @@ ___
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
 [com.amazonaws/aws-lambda-java-events "2.2.8"]
 [com.amazonaws/aws-lambda-java-log4j "1.0.1"]
-[com.amazonaws/aws-lambda-java-log4j2 "1.1.1"]
+[com.amazonaws/aws-lambda-java-log4j2 "1.2.0"]
 ```
 
 [sbt](http://www.scala-sbt.org)
@@ -72,7 +72,7 @@ ___
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
 "com.amazonaws" % "aws-lambda-java-events" % "2.2.8"
 "com.amazonaws" % "aws-lambda-java-log4j" % "1.0.1"
-"com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.1"
+"com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0"
 ```
 
 # Using aws-lambda-java-core

--- a/aws-lambda-java-log4j2/README.md
+++ b/aws-lambda-java-log4j2/README.md
@@ -10,17 +10,17 @@ Example for Maven pom.xml
   <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-log4j2</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
   </dependency>
   <dependency>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-core</artifactId>
-    <version>2.8.2</version>
+    <version>2.13.2</version>
   </dependency>
   <dependency>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-api</artifactId>
-    <version>2.8.2</version>
+    <version>2.13.2</version>
   </dependency>
   ....
 </dependencies>

--- a/aws-lambda-java-log4j2/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-log4j2/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### May 05, 2020
+`1.2.0`:
+- Updated `log4j-core` and `log4j-api` dependencies to `2.13.2`
+
 ### Apr 28, 2020
 `1.1.1`:
 - Added missing XML namespace declarations to `pom.xml` file ([#97](https://github.com/aws/aws-lambda-java-libs/issues/97))

--- a/aws-lambda-java-log4j2/pom.xml
+++ b/aws-lambda-java-log4j2/pom.xml
@@ -5,12 +5,12 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-log4j2</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
-    <name>AWS Lambda Java Log4j 2.8 Libraries</name>
+    <name>AWS Lambda Java Log4j 2.x Libraries</name>
     <description>
-        Support for using log4j 2.8 with AWS Lambda.
+        Support for using Log4j 2.x with AWS Lambda.
     </description>
     <url>https://aws.amazon.com/lambda/</url>
     <licenses>
@@ -34,6 +34,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <log4j.version>2.13.2</log4j.version>
     </properties>
 
     <distributionManagement>
@@ -52,12 +53,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.8.2</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.8.2</version>
+            <version>${log4j.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
*Issue #, if available:*
Previous PR: https://github.com/aws/aws-lambda-java-libs/pull/56

*Description of changes:*
- Updated `log4j-core` and `log4j-api` dependencies from `2.8.2` to `2.13.2` with relevant documentation changes
- Renamed `AWS Lambda Java Log4j 2.8 Libraries` -> `AWS Lambda Java Log4j 2.x Libraries`
- Bumped `aws-lambda-java-log4j2` to `1.2.0`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
