### PR TITLE
Add events-sdk-transformer to build workflow

### DIFF
--- a/.github/workflows/maven-pkg-all.yml
+++ b/.github/workflows/maven-pkg-all.yml
@@ -24,6 +24,8 @@ jobs:
       run: mvn -B package --file aws-lambda-java-core/pom.xml
     - name: Build events with Maven
       run: mvn -B package --file aws-lambda-java-events/pom.xml
+    - name: Build events-sdk-transformer with Maven
+      run: mvn -B package --file aws-lambda-java-events-sdk-transformer/pom.xml
     - name: Build log4j with Maven
       run: mvn -B package --file aws-lambda-java-log4j/pom.xml
     - name: Build log4j2 with Maven


### PR DESCRIPTION
*Description of changes:*
With the addition of the `aws-lambda-java-events-sdk-transformer` library, we should also add it to the build Action workflow file. This PR does just that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
