### PR TITLE
Bump events lib version to 2.2.9

### DIFF
--- a/.github/workflows/maven-build-all.yml
+++ b/.github/workflows/maven-build-all.yml
@@ -19,11 +19,14 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-
+    
+    # Install base modules
     - name: Build core with Maven
-      run: mvn -B package --file aws-lambda-java-core/pom.xml
+      run: mvn -B install --file aws-lambda-java-core/pom.xml
     - name: Build events with Maven
-      run: mvn -B package --file aws-lambda-java-events/pom.xml
+      run: mvn -B install --file aws-lambda-java-events/pom.xml
+
+    # Package modules that depend on base modules
     - name: Build events-sdk-transformer with Maven
       run: mvn -B package --file aws-lambda-java-events-sdk-transformer/pom.xml
     - name: Build log4j with Maven

--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -21,7 +21,7 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>2.2.8</version>
+        <version>2.2.9</version>
     </dependency>
 </dependencies>
 ```

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,3 @@
 ### Apr 29, 2020
 `1.0.0`:
-- Added AWS SDK V2 transformers for `DynamodbEvent` in `aws-lambda-java-events` versions up to and including `2.2.8`
+- Added AWS SDK V2 transformers for `DynamodbEvent` in `aws-lambda-java-events` versions up to and including `2.x`

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>2.2.8</version>
+      <version>2.2.9</version>
       <scope>provided</scope>
     </dependency>
 

--- a/aws-lambda-java-events/README.md
+++ b/aws-lambda-java-events/README.md
@@ -48,7 +48,7 @@ so the dependencies section in the pom.xml file would like this
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>2.2.8</version>
+        <version>2.2.9</version>
     </dependency>
     ...
 </dependencies>
@@ -69,7 +69,7 @@ For the S3 event the pom would look like this:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>2.2.8</version>
+        <version>2.2.9</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>
@@ -95,7 +95,7 @@ For the Kinesis event
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>2.2.8</version>
+        <version>2.2.9</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>
@@ -121,7 +121,7 @@ For the Dynamodb event
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>2.2.8</version>
+        <version>2.2.9</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### May 13, 2020
+`2.2.9`:
+- Added field `operationName` to `APIGatewayProxyRequestEvent` ([#126](https://github.com/aws/aws-lambda-java-libs/pull/126))
+
 ### Apr 28, 2020
 `2.2.8`:
 - Added missing XML namespace declarations to `pom.xml` file ([#97](https://github.com/aws/aws-lambda-java-libs/issues/97))

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events</artifactId>
-  <version>2.2.8</version>
+  <version>2.2.9</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events Library</name>


### PR DESCRIPTION
*Description of changes:*
`aws-lambda-java-events` version bump to `2.2.9` in order to cut a release containing changes from https://github.com/aws/aws-lambda-java-libs/pull/126


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
