### PR TITLE
Update build workflow to install instead of package

### DIFF
--- a/.github/workflows/maven-build-all.yml
+++ b/.github/workflows/maven-build-all.yml
@@ -19,11 +19,14 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-
+    
+    # Install base modules
     - name: Build core with Maven
-      run: mvn -B package --file aws-lambda-java-core/pom.xml
+      run: mvn -B install --file aws-lambda-java-core/pom.xml
     - name: Build events with Maven
-      run: mvn -B package --file aws-lambda-java-events/pom.xml
+      run: mvn -B install --file aws-lambda-java-events/pom.xml
+
+    # Package modules that depend on base modules
     - name: Build events-sdk-transformer with Maven
       run: mvn -B package --file aws-lambda-java-events-sdk-transformer/pom.xml
     - name: Build log4j with Maven


### PR DESCRIPTION
*Description of changes:*
This ensures inter-package dependencies are resolved locally by running `mvn install` on modules that are depended on by others locally.

eg:
- `aws-lambda-java-core` is depended on by `aws-lambda-java-log4j` and `aws-lambda-java-log4j2` 
- `aws-lambda-java-events` is depended on by `aws-lambda-java-events-sdk-transformer`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
