### PR TITLE
Update SDK Transformer for events v3.0.0

### DIFF
--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -16,17 +16,17 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-        <version>1.0.0</version>
+        <version>2.0.0</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>2.2.9</version>
+        <version>3.0.0</version>
     </dependency>
 </dependencies>
 ```
 
-To use this library as a transformer to the AWS DynamoDB Java SDK v2, also add the following dependencies to your `pom.xml` file:
+To use this library as a transformer to the AWS DynamoDB Java SDK v2, also add the following dependency to your `pom.xml` file:
 
 ```xml
 <dependencies>
@@ -35,14 +35,8 @@ To use this library as a transformer to the AWS DynamoDB Java SDK v2, also add t
         <artifactId>dynamodb</artifactId>
         <version>2.11.12</version>
     </dependency>
-    <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-dynamodb</artifactId>
-        <version>1.11.163</version>
-    </dependency>
 </dependencies>
 ```
-*Note that because `aws-lambda-java-events` version 2 requires the DynamoDB v1 SDK, this is also required for this library.*
 
 
 ### Example Usage

--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -33,7 +33,7 @@ To use this library as a transformer to the AWS DynamoDB Java SDK v2, also add t
     <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>dynamodb</artifactId>
-        <version>2.11.12</version>
+        <version>2.13.18</version>
     </dependency>
 </dependencies>
 ```

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,6 +1,7 @@
 ### May 20, 2020
 `2.0.0`:
 - Updated AWS SDK V2 transformers for `DynamodbEvent` to work with `aws-lambda-java-events` versions `3.0.0` and up
+- Bump `software.amazon.awssdk:dynamodb` to version `2.13.18`
 
 ### Apr 29, 2020
 `1.0.0`:

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### May 20, 2020
+`2.0.0`:
+- Updated AWS SDK V2 transformers for `DynamodbEvent` to work with `aws-lambda-java-events` versions `3.0.0` and up
+
 ### Apr 29, 2020
 `1.0.0`:
 - Added AWS SDK V2 transformers for `DynamodbEvent` in `aws-lambda-java-events` versions up to and including `2.x`

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -54,14 +54,8 @@
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-dynamodb</artifactId>
-      <version>1.11.163</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>2.2.9</version>
+      <version>3.0.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>dynamodb</artifactId>
-      <version>2.11.12</version>
+      <version>2.13.18</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events SDK Transformer Library</name>

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbAttributeValueTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbAttributeValueTransformer.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 
 public class DynamodbAttributeValueTransformer {
 
-    public static AttributeValue toAttributeValueV2(final com.amazonaws.services.dynamodbv2.model.AttributeValue value) {
+    public static AttributeValue toAttributeValueV2(final com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue value) {
         if (Objects.nonNull(value.getS())) {
             return AttributeValue.builder()
                     .s(value.getS())
@@ -71,7 +71,7 @@ public class DynamodbAttributeValueTransformer {
     }
 
     static Map<String, AttributeValue> toAttributeValueMapV2(
-            final Map<String, com.amazonaws.services.dynamodbv2.model.AttributeValue> attributeValueMap
+            final Map<String, com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue> attributeValueMap
     ) {
         return attributeValueMap
                 .entrySet()

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbIdentityTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbIdentityTransformer.java
@@ -4,7 +4,7 @@ import software.amazon.awssdk.services.dynamodb.model.Identity;
 
 public class DynamodbIdentityTransformer {
 
-    public static Identity toIdentityV2(final com.amazonaws.services.dynamodbv2.model.Identity identity) {
+    public static Identity toIdentityV2(final com.amazonaws.services.lambda.runtime.events.models.dynamodb.Identity identity) {
         return Identity.builder()
                 .principalId(identity.getPrincipalId())
                 .type(identity.getType())

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbStreamRecordTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbStreamRecordTransformer.java
@@ -4,7 +4,7 @@ import software.amazon.awssdk.services.dynamodb.model.StreamRecord;
 
 public class DynamodbStreamRecordTransformer {
 
-    public static StreamRecord toStreamRecordV2(final com.amazonaws.services.dynamodbv2.model.StreamRecord streamRecord) {
+    public static StreamRecord toStreamRecordV2(final com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord streamRecord) {
         return StreamRecord.builder()
                 .approximateCreationDateTime(
                         streamRecord.getApproximateCreationDateTime().toInstant()

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbAttributeValueTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbAttributeValueTransformerTest.java
@@ -1,6 +1,6 @@
 package com.amazonaws.services.lambda.runtime.events.transformers.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbIdentityTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbIdentityTransformerTest.java
@@ -10,16 +10,17 @@ class DynamodbIdentityTransformerTest {
     private static final String identityType = "type";
 
     //region Identity_event
-    public static final com.amazonaws.services.dynamodbv2.model.Identity identity_event = new com.amazonaws.services.dynamodbv2.model.Identity()
-                                .withPrincipalId(principalId)
-                                .withType(identityType);
+    public static final com.amazonaws.services.lambda.runtime.events.models.dynamodb.Identity identity_event =
+            new com.amazonaws.services.lambda.runtime.events.models.dynamodb.Identity()
+                    .withPrincipalId(principalId)
+                    .withType(identityType);
     //endregion
 
     //region Identity_v2
     public static final Identity identity_v2 = Identity.builder()
-                            .principalId(principalId)
-                            .type(identityType)
-                            .build();
+            .principalId(principalId)
+            .type(identityType)
+            .build();
     //endregion
 
     @Test

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbStreamRecordTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbStreamRecordTransformerTest.java
@@ -1,7 +1,7 @@
 package com.amazonaws.services.lambda.runtime.events.transformers.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.StreamViewType;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamViewType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.StreamRecord;
@@ -37,62 +37,63 @@ class DynamodbStreamRecordTransformerTest {
     private static final Date approximateCreationDateTime = new Date();
 
     //region StreamRecord_event
-    public static final com.amazonaws.services.dynamodbv2.model.StreamRecord streamRecord_event = new com.amazonaws.services.dynamodbv2.model.StreamRecord()
-            .withKeys(ImmutableMap.<String, AttributeValue> builder()
-                    .put(keyNK, attributeValueN_event)
-                    .put(keyNSK, attributeValueNS_event)
-                    .put(keySK, attributeValueS_event)
-                    .put(keySSK, attributeValueSS_event)
-                    .put(keyBK, attributeValueB_event)
-                    .put(keyBSK, attributeValueBS_event)
-                    .put(keyBOOLK, attributeValueBOOL_event)
-                    .put(keyNULK, attributeValueNUL_event)
-                    .put(keyMK, attributeValueM_event)
-                    .put(keyLK, attributeValueL_event)
-                    .build()
-            )
-            .withOldImage(ImmutableMap.of(
-                    oldImageSK, attributeValueS_event,
-                    keyNK, attributeValueN_event
-            ))
-            .withNewImage(ImmutableMap.of(
-                    newImageSK, attributeValueS_event,
-                    keyNK, attributeValueN_event
-            ))
-            .withStreamViewType(StreamViewType.fromValue(streamViewType))
-            .withSequenceNumber(sequenceNumber)
-            .withSizeBytes(sizeBytes)
-            .withApproximateCreationDateTime(approximateCreationDateTime);
+    public static final com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord streamRecord_event =
+            new com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord()
+                    .withKeys(ImmutableMap.<String, AttributeValue> builder()
+                            .put(keyNK, attributeValueN_event)
+                            .put(keyNSK, attributeValueNS_event)
+                            .put(keySK, attributeValueS_event)
+                            .put(keySSK, attributeValueSS_event)
+                            .put(keyBK, attributeValueB_event)
+                            .put(keyBSK, attributeValueBS_event)
+                            .put(keyBOOLK, attributeValueBOOL_event)
+                            .put(keyNULK, attributeValueNUL_event)
+                            .put(keyMK, attributeValueM_event)
+                            .put(keyLK, attributeValueL_event)
+                            .build()
+                    )
+                    .withOldImage(ImmutableMap.of(
+                            oldImageSK, attributeValueS_event,
+                            keyNK, attributeValueN_event
+                    ))
+                    .withNewImage(ImmutableMap.of(
+                            newImageSK, attributeValueS_event,
+                            keyNK, attributeValueN_event
+                    ))
+                    .withStreamViewType(StreamViewType.fromValue(streamViewType))
+                    .withSequenceNumber(sequenceNumber)
+                    .withSizeBytes(sizeBytes)
+                    .withApproximateCreationDateTime(approximateCreationDateTime);
     //endregion
 
     //region StreamRecord_v2
     public static final StreamRecord streamRecord_v2 = StreamRecord.builder()
-                            .approximateCreationDateTime(approximateCreationDateTime.toInstant())
-                            .keys(ImmutableMap.<String, software.amazon.awssdk.services.dynamodb.model.AttributeValue> builder()
-                                    .put(keyNK, attributeValueN_v2)
-                                    .put(keyNSK, attributeValueNS_v2)
-                                    .put(keySK, attributeValueS_v2)
-                                    .put(keySSK, attributeValueSS_v2)
-                                    .put(keyBK, attributeValueB_v2)
-                                    .put(keyBSK, attributeValueBS_v2)
-                                    .put(keyBOOLK, attributeValueBOOL_v2)
-                                    .put(keyNULK, attributeValueNUL_v2)
-                                    .put(keyMK, attributeValueM_v2)
-                                    .put(keyLK, attributeValueL_v2)
-                                    .build()
-                            )
-                            .oldImage(ImmutableMap.of(
-                                    oldImageSK, attributeValueS_v2,
-                                    keyNK, attributeValueN_v2
-                            ))
-                            .newImage(ImmutableMap.of(
-                                    newImageSK, attributeValueS_v2,
-                                    keyNK, attributeValueN_v2
-                            ))
-                            .sequenceNumber(sequenceNumber)
-                            .sizeBytes(sizeBytes)
-                            .streamViewType(streamViewType)
-                            .build();
+            .approximateCreationDateTime(approximateCreationDateTime.toInstant())
+            .keys(ImmutableMap.<String, software.amazon.awssdk.services.dynamodb.model.AttributeValue> builder()
+                    .put(keyNK, attributeValueN_v2)
+                    .put(keyNSK, attributeValueNS_v2)
+                    .put(keySK, attributeValueS_v2)
+                    .put(keySSK, attributeValueSS_v2)
+                    .put(keyBK, attributeValueB_v2)
+                    .put(keyBSK, attributeValueBS_v2)
+                    .put(keyBOOLK, attributeValueBOOL_v2)
+                    .put(keyNULK, attributeValueNUL_v2)
+                    .put(keyMK, attributeValueM_v2)
+                    .put(keyLK, attributeValueL_v2)
+                    .build()
+            )
+            .oldImage(ImmutableMap.of(
+                    oldImageSK, attributeValueS_v2,
+                    keyNK, attributeValueN_v2
+            ))
+            .newImage(ImmutableMap.of(
+                    newImageSK, attributeValueS_v2,
+                    keyNK, attributeValueN_v2
+            ))
+            .sequenceNumber(sequenceNumber)
+            .sizeBytes(sizeBytes)
+            .streamViewType(streamViewType)
+            .build();
     //endregion
 
     @Test


### PR DESCRIPTION
*Description of changes:*
- Update `aws-lambda-java-events` to version `3.0.0` in SDK Transformer lib dependencies
- Bump DynamoDB SDK to version `2.13.18`
- Bump `aws-lambda-java-events-sdk-transformer` to version `2.0.0`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
