### PR TITLE
Bump events library to 3.1.0

### DIFF
--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -21,7 +21,7 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
     </dependency>
 </dependencies>
 ```

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,7 +1,7 @@
 ### May 20, 2020
 `2.0.0`:
 - Updated AWS SDK V2 transformers for `DynamodbEvent` to work with `aws-lambda-java-events` versions `3.0.0` and up
-- Bump `software.amazon.awssdk:dynamodb` to version `2.13.18`
+- Bumped `software.amazon.awssdk:dynamodb` to version `2.13.18`
 
 ### Apr 29, 2020
 `1.0.0`:

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/aws-lambda-java-events/README.md
+++ b/aws-lambda-java-events/README.md
@@ -47,7 +47,7 @@
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
     </dependency>
     ...
 </dependencies>
@@ -57,19 +57,19 @@
 
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
-'com.amazonaws:aws-lambda-java-events:3.0.0'
+'com.amazonaws:aws-lambda-java-events:3.1.0'
 ```
 
 [Leiningen](http://leiningen.org) and [Boot](http://boot-clj.com)
 
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
-[com.amazonaws/aws-lambda-java-events "3.0.0"]
+[com.amazonaws/aws-lambda-java-events "3.1.0"]
 ```
 
 [sbt](http://www.scala-sbt.org)
 
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
-"com.amazonaws" % "aws-lambda-java-events" % "3.0.0"
+"com.amazonaws" % "aws-lambda-java-events" % "3.1.0"
 ```

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,4 +1,5 @@
-### Upcoming
+### May 20, 2020
+`3.1.0`:
 - Added support for Application Load Balancer Target Events ([#131](https://github.com/aws/aws-lambda-java-libs/pull/131))
   - `ApplicationLoadBalancerRequestEvent`
   - `ApplicationLoadBalancerResponseEvent`

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events</artifactId>
-  <version>3.0.0</version>
+  <version>3.1.0</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events Library</name>


### PR DESCRIPTION
*Purpose*
Pre-release of:
- `aws-lambda-java-events` version `3.1.0`
- `aws-lambda-java-events-sdk-transformer` version `2.0.0`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
