### PR TITLE
Remove Joda-Time dependency

### DIFF
--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -45,12 +45,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.6</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>5.5.2</version>

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CodeCommitEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CodeCommitEvent.java
@@ -1,8 +1,7 @@
 package com.amazonaws.services.lambda.runtime.events;
 
-import org.joda.time.DateTime;
-
 import java.io.Serializable;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
@@ -270,7 +269,7 @@ public class CodeCommitEvent implements Serializable, Cloneable {
 
         private String eventVersion;
 
-        private DateTime eventTime;
+        private ZonedDateTime eventTime;
 
         private String eventTriggerName;
 
@@ -348,14 +347,14 @@ public class CodeCommitEvent implements Serializable, Cloneable {
         /**
          * @return event timestamp
          */
-        public DateTime getEventTime() {
+        public ZonedDateTime getEventTime() {
             return this.eventTime;
         }
 
         /**
          * @param eventTime event timestamp
          */
-        public void setEventTime(DateTime eventTime) {
+        public void setEventTime(ZonedDateTime eventTime) {
             this.eventTime = eventTime;
         }
 
@@ -363,7 +362,7 @@ public class CodeCommitEvent implements Serializable, Cloneable {
          * @param eventTime event timestamp
          * @return Record
          */
-        public Record withEventTime(DateTime eventTime) {
+        public Record withEventTime(ZonedDateTime eventTime) {
             setEventTime(eventTime);
             return this;
         }

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SNSEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SNSEvent.java
@@ -12,9 +12,8 @@
  */
 package com.amazonaws.services.lambda.runtime.events;
 
-import org.joda.time.DateTime;
-
 import java.io.Serializable;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -181,7 +180,7 @@ public class SNSEvent implements Serializable, Cloneable {
 
         private String signature;
 
-        private DateTime timestamp;
+        private ZonedDateTime timestamp;
 
         private String topicArn;
 
@@ -421,7 +420,7 @@ public class SNSEvent implements Serializable, Cloneable {
          * Gets the message time stamp
          * @return timestamp of sns message
          */
-        public DateTime getTimestamp() {
+        public ZonedDateTime getTimestamp() {
             return timestamp;
         }
 
@@ -429,7 +428,7 @@ public class SNSEvent implements Serializable, Cloneable {
          * Sets the message time stamp
          * @param timestamp A Date object representing the message time stamp
          */
-        public void setTimestamp(DateTime timestamp) {
+        public void setTimestamp(ZonedDateTime timestamp) {
             this.timestamp = timestamp;
         }
 
@@ -437,7 +436,7 @@ public class SNSEvent implements Serializable, Cloneable {
          * @param timestamp timestamp
          * @return SNS
          */
-        public SNS withTimestamp(DateTime timestamp) {
+        public SNS withTimestamp(ZonedDateTime timestamp) {
             setTimestamp(timestamp);
             return this;
         }

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ScheduledEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ScheduledEvent.java
@@ -13,9 +13,8 @@
 
 package com.amazonaws.services.lambda.runtime.events;
 
-import org.joda.time.DateTime;
-
 import java.io.Serializable;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -38,7 +37,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
 
     private String id;
 
-    private DateTime time;
+    private ZonedDateTime time;
 
     private List<String> resources;
 
@@ -69,7 +68,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setAccount(account);
         return this;
     }
-    
+
     /**
      * @return the aws region
      */
@@ -92,7 +91,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setRegion(region);
         return this;
     }
-    
+
     /**
      * @return The details of the events (usually left blank)
      */
@@ -115,7 +114,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setDetail(detail);
         return this;
     }
-    
+
     /**
      * @return The details type - see cloud watch events for more info
      */
@@ -138,7 +137,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setDetailType(detailType);
         return this;
     }
-    
+
     /**
      * @return the soruce of the event
      */
@@ -161,18 +160,18 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setSource(source);
         return this;
     }
-    
+
     /**
      * @return the timestamp for when the event is scheduled
      */
-    public DateTime getTime() {
+    public ZonedDateTime getTime() {
         return this.time;
     }
 
     /**
      * @param time the timestamp for when the event is scheduled
      */
-    public void setTime(DateTime time) {
+    public void setTime(ZonedDateTime time) {
         this.time = time;
     }
 
@@ -180,11 +179,11 @@ public class ScheduledEvent implements Serializable, Cloneable {
      * @param time the timestamp for when the event is scheduled
      * @return ScheduledEvent
      */
-    public ScheduledEvent withTime(DateTime time) {
+    public ScheduledEvent withTime(ZonedDateTime time) {
         setTime(time);
         return this;
     }
-    
+
     /**
      * @return the id of the event
      */
@@ -207,7 +206,7 @@ public class ScheduledEvent implements Serializable, Cloneable {
         setId(id);
         return this;
     }
-    
+
     /**
      * @return the resources used by event
      */
@@ -331,5 +330,5 @@ public class ScheduledEvent implements Serializable, Cloneable {
             throw new IllegalStateException("Got a CloneNotSupportedException from Object.clone()", e);
         }
     }
-    
+
 }

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/models/s3/S3EventNotification.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/models/s3/S3EventNotification.java
@@ -12,10 +12,9 @@
  */
 package com.amazonaws.services.lambda.runtime.events.models.s3;
 
-import org.joda.time.DateTime;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
@@ -244,7 +243,7 @@ public class S3EventNotification {
         private final String awsRegion;
         private final String eventName;
         private final String eventSource;
-        private DateTime eventTime;
+        private ZonedDateTime eventTime;
         private final String eventVersion;
         private final RequestParametersEntity requestParameters;
         private final ResponseElementsEntity responseElements;
@@ -261,7 +260,7 @@ public class S3EventNotification {
 
             if (eventTime != null)
             {
-                this.eventTime = DateTime.parse(eventTime);
+                this.eventTime = ZonedDateTime.parse(eventTime);
             }
 
             this.eventVersion = eventVersion;
@@ -283,7 +282,7 @@ public class S3EventNotification {
             return eventSource;
         }
 
-        public DateTime getEventTime() {
+        public ZonedDateTime getEventTime() {
             return eventTime;
         }
 


### PR DESCRIPTION
Issue #72

Description of changes:

- remove **joda-time** library dependency
- replace **org.joda.time.DateTime** with **java.time.ZonedDateTime**

This PR duplicates [year and a half old one](https://github.com/aws/aws-lambda-java-libs/pull/75) which is outdated now.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
