### PR TITLE
fix npe when mapping insert / delete events.

### DIFF
--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbStreamRecordTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbStreamRecordTransformer.java
@@ -1,29 +1,28 @@
 package com.amazonaws.services.lambda.runtime.events.transformers.dynamodb;
 
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.StreamRecord;
-
-import java.util.Map;
 
 public class DynamodbStreamRecordTransformer {
 
     public static StreamRecord toStreamRecordV2(final com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord streamRecord) {
-        Map<String, AttributeValue> newImage = streamRecord.getNewImage() != null
-                ? DynamodbAttributeValueTransformer.toAttributeValueMapV2(streamRecord.getNewImage())
-                : null;
-        Map<String, AttributeValue> oldImage = streamRecord.getOldImage() != null
-                ? DynamodbAttributeValueTransformer.toAttributeValueMapV2(streamRecord.getOldImage())
-                : null;
 
         return StreamRecord.builder()
                 .approximateCreationDateTime(
-                        streamRecord.getApproximateCreationDateTime().toInstant()
+                    streamRecord.getApproximateCreationDateTime().toInstant()
                 )
                 .keys(
-                        DynamodbAttributeValueTransformer.toAttributeValueMapV2(streamRecord.getKeys())
+                    DynamodbAttributeValueTransformer.toAttributeValueMapV2(streamRecord.getKeys())
                 )
-                .newImage(newImage)
-                .oldImage(oldImage)
+                .newImage(
+                    streamRecord.getNewImage() != null
+                        ? DynamodbAttributeValueTransformer.toAttributeValueMapV2(streamRecord.getNewImage())
+                        : null
+                )
+                .oldImage(
+                    streamRecord.getOldImage() != null
+                        ? DynamodbAttributeValueTransformer.toAttributeValueMapV2(streamRecord.getOldImage())
+                        : null
+                )
                 .sequenceNumber(streamRecord.getSequenceNumber())
                 .sizeBytes(streamRecord.getSizeBytes())
                 .streamViewType(streamRecord.getStreamViewType())

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbStreamRecordTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbStreamRecordTransformer.java
@@ -1,10 +1,20 @@
 package com.amazonaws.services.lambda.runtime.events.transformers.dynamodb;
 
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.StreamRecord;
+
+import java.util.Map;
 
 public class DynamodbStreamRecordTransformer {
 
     public static StreamRecord toStreamRecordV2(final com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord streamRecord) {
+        Map<String, AttributeValue> newImage = streamRecord.getNewImage() != null
+                ? DynamodbAttributeValueTransformer.toAttributeValueMapV2(streamRecord.getNewImage())
+                : null;
+        Map<String, AttributeValue> oldImage = streamRecord.getOldImage() != null
+                ? DynamodbAttributeValueTransformer.toAttributeValueMapV2(streamRecord.getOldImage())
+                : null;
+
         return StreamRecord.builder()
                 .approximateCreationDateTime(
                         streamRecord.getApproximateCreationDateTime().toInstant()
@@ -12,12 +22,8 @@ public class DynamodbStreamRecordTransformer {
                 .keys(
                         DynamodbAttributeValueTransformer.toAttributeValueMapV2(streamRecord.getKeys())
                 )
-                .newImage(
-                        DynamodbAttributeValueTransformer.toAttributeValueMapV2(streamRecord.getNewImage())
-                )
-                .oldImage(
-                        DynamodbAttributeValueTransformer.toAttributeValueMapV2(streamRecord.getOldImage())
-                )
+                .newImage(newImage)
+                .oldImage(oldImage)
                 .sequenceNumber(streamRecord.getSequenceNumber())
                 .sizeBytes(streamRecord.getSizeBytes())
                 .streamViewType(streamRecord.getStreamViewType())

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbStreamRecordTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/dynamodb/DynamodbStreamRecordTransformerTest.java
@@ -101,4 +101,24 @@ class DynamodbStreamRecordTransformerTest {
         StreamRecord convertedStreamRecord = DynamodbStreamRecordTransformer.toStreamRecordV2(streamRecord_event);
         Assertions.assertEquals(streamRecord_v2, convertedStreamRecord);
     }
+
+    @Test
+    public void testToStreamRecordV2WhenOldImageIsNull() {
+        com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord streamRecord = streamRecord_event.clone();
+        streamRecord.setOldImage(null);
+
+        Assertions.assertDoesNotThrow(() -> {
+            DynamodbStreamRecordTransformer.toStreamRecordV2(streamRecord);
+        });
+    }
+
+    @Test
+    public void testToStreamRecordV2WhenNewImageIsNull() {
+        com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord streamRecord = streamRecord_event.clone();
+        streamRecord.setNewImage(null);
+
+        Assertions.assertDoesNotThrow(() -> {
+            DynamodbStreamRecordTransformer.toStreamRecordV2(streamRecord);
+        });
+    }
 }


### PR DESCRIPTION
Insert event does not have oldImage. Remove event does not have newImage. At this moment library just throws nullPointerException

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
