### PR TITLE
Bump sdk transformer lib to version 2.0.1

### DIFF
--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -16,7 +16,7 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### June 15, 2020
+`2.0.1`:
+- Fixed NPE when mapping insert/delete events ([#143](https://github.com/aws/aws-lambda-java-libs/pull/143))
+
 ### May 20, 2020
 `2.0.0`:
 - Updated AWS SDK V2 transformers for `DynamodbEvent` to work with `aws-lambda-java-events` versions `3.0.0` and up

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events SDK Transformer Library</name>


### PR DESCRIPTION
Pre-release of `aws-lambda-java-events-sdk-transformer` version `2.0.1`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
