### PR TITLE
Create explicitly getter and setter for the isBase64Encoded variable

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ApplicationLoadBalancerRequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ApplicationLoadBalancerRequestEvent.java
@@ -44,4 +44,17 @@ public class ApplicationLoadBalancerRequestEvent implements Serializable, Clonea
     private String body;
     private boolean isBase64Encoded;
 
+    /**
+     * @return whether the body String is base64 encoded.
+     */
+    public Boolean getIsBase64Encoded() {
+        return this.isBase64Encoded;
+    }
+
+    /**
+     * @param isBase64Encoded Whether the body String is base64 encoded
+     */
+    public void setIsBase64Encoded(Boolean isBase64Encoded) {
+        this.isBase64Encoded = isBase64Encoded;
+    }
 }

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ApplicationLoadBalancerResponseEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ApplicationLoadBalancerResponseEvent.java
@@ -26,4 +26,17 @@ public class ApplicationLoadBalancerResponseEvent implements Serializable, Clone
     private Map<String, List<String>> multiValueHeaders;
     private String body;
 
+    /**
+     * @return whether the body String is base64 encoded.
+     */
+    public Boolean getIsBase64Encoded() {
+        return this.isBase64Encoded;
+    }
+
+    /**
+     * @param isBase64Encoded Whether the body String is base64 encoded
+     */
+    public void setIsBase64Encoded(Boolean isBase64Encoded) {
+        this.isBase64Encoded = isBase64Encoded;
+    }
 }


### PR DESCRIPTION
*Description of changes:*
Create explicitly getter and setter for the isBase64Encoded because Jackson remove the prefix is from the boolean variables when serializing. ALB expects a key-value isBase64Encoded not base64Encoded in the response JSON document. Thus, the JSON serialization doesn't work properly for Base64 bodies. It is also coherent with the APIGatewayProxy* ones.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
