### PR TITLE
Stage events v3.2.0 and sdk-transformer v2.0.3 releases

### DIFF
--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -21,7 +21,7 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.0</version>
     </dependency>
 </dependencies>
 ```

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### August 11, 2020
+`2.0.3`:
+- Bumped `aws-lambda-java-events` to version `3.2.0`
+
 ### July 31, 2020
 `2.0.2`:
 - Bumped `aws-lambda-java-events` to version `3.1.1`

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>2.0.2</version>
+  <version>2.0.3</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events SDK Transformer Library</name>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>3.1.1</version>
+      <version>3.2.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/aws-lambda-java-events/README.md
+++ b/aws-lambda-java-events/README.md
@@ -1,4 +1,4 @@
-# AWS Lambda Java Events v3.0
+# AWS Lambda Java Events v3
 
 ### Event Models Supported
 * `APIGatewayProxyRequestEvent`
@@ -16,6 +16,7 @@
 * `ConfigEvent`
 * `DynamodbEvent`
 * `IoTButtonEvent`
+* `KafkaEvent`
 * `KinesisAnalyticsFirehoseInputPreprocessingEvent`
 * `KinesisAnalyticsInputPreprocessingResponse`
 * `KinesisAnalyticsOutputDeliveryEvent`
@@ -47,7 +48,7 @@
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.0</version>
     </dependency>
     ...
 </dependencies>
@@ -57,19 +58,19 @@
 
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
-'com.amazonaws:aws-lambda-java-events:3.1.1'
+'com.amazonaws:aws-lambda-java-events:3.2.0'
 ```
 
 [Leiningen](http://leiningen.org) and [Boot](http://boot-clj.com)
 
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
-[com.amazonaws/aws-lambda-java-events "3.1.1"]
+[com.amazonaws/aws-lambda-java-events "3.2.0"]
 ```
 
 [sbt](http://www.scala-sbt.org)
 
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
-"com.amazonaws" % "aws-lambda-java-events" % "3.1.1"
+"com.amazonaws" % "aws-lambda-java-events" % "3.2.0"
 ```

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### August 11, 2020
+`3.2.0`:
+- Added support for Kafka Events ([#154](https://github.com/aws/aws-lambda-java-libs/pull/154))
+
 ### July 31, 2020
 `3.1.1`:
 - Fixed Base64 encoding for ALB and API Gateway HTTP events ([#150](https://github.com/aws/aws-lambda-java-libs/pull/131))

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events</artifactId>
-  <version>3.1.1</version>
+  <version>3.2.0</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events Library</name>


### PR DESCRIPTION
*Description of changes:*
- Bumping `aws-lambda-java-events` to version `3.2.0`
- Bumping `aws-lambda-java-events-sdk-transformer` to version `2.0.3`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
