### PR TITLE
Update apigatewayv2 request context

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayV2HTTPEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayV2HTTPEvent.java
@@ -61,6 +61,8 @@ public class APIGatewayV2HTTPEvent {
         @NoArgsConstructor
         public static class Authorizer {
             private JWT jwt;
+            private Map<String, Object> lambda;
+            private IAM iam;
 
             @AllArgsConstructor
             @Builder(setterPrefix = "with")
@@ -82,6 +84,30 @@ public class APIGatewayV2HTTPEvent {
             private String protocol;
             private String sourceIp;
             private String userAgent;
+        }
+
+        @AllArgsConstructor
+        @Builder(setterPrefix = "with")
+        @Data
+        @NoArgsConstructor
+        public static class IAM {
+            private String accessKey;
+            private String accountId;
+            private String callerId;
+            private CognitoIdentity cognitoIdentity;
+            private String principalOrgId;
+            private String userArn;
+            private String userId;
+        }
+
+        @AllArgsConstructor
+        @Builder(setterPrefix = "with")
+        @Data
+        @NoArgsConstructor
+        public static class CognitoIdentity {
+            private List<String> amr;
+            private String identityId;
+            private String identityPoolId;
         }
     }
 }


### PR DESCRIPTION
*Description of changes:*
On Sept 9th,[ API Gateway launched support](https://aws.amazon.com/about-aws/whats-new/2020/09/api-gateway-http-apis-now-supports-lambda-and-iam-authorization-options/) for customers to secure Amazon API Gateway HTTP APIs using two new authorization options: Lambda authorizers and IAM authorizers. These new options enable customers to make flexible authorization decisions by providing an AWS Lambda function, or leveraging AWS IAM policies to control access to their APIs without writing any code. 

Updating API Gateway v2 event to support new context variables.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
