### PR TITLE
Stage events v3.4.0 and sdk-transformer 2.0.6

### DIFF
--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -16,12 +16,12 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-        <version>2.0.5</version>
+        <version>2.0.6</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
     </dependency>
 </dependencies>
 ```

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,8 @@
+### October 07, 2020
+`2.0.6`:
+- Fixed NPE when UserIdentity is null ([#169](https://github.com/aws/aws-lambda-java-libs/pull/169))
+- Bumped `aws-lambda-java-events` to version `3.4.0`
+
 ### September 23, 2020
 `2.0.5`:
 - Bumped `aws-lambda-java-events` to version `3.3.1`

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>2.0.5</version>
+  <version>2.0.6</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events SDK Transformer Library</name>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>3.3.1</version>
+      <version>3.4.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/aws-lambda-java-events/README.md
+++ b/aws-lambda-java-events/README.md
@@ -1,8 +1,10 @@
 # AWS Lambda Java Events v3
 
 ### Event Models Supported
+* `APIGatewayCustomAuthorizerEvent`
 * `APIGatewayProxyRequestEvent`
 * `APIGatewayProxyResponseEvent`
+* `APIGatewayV2CustomAuthorizerEvent`
 * `APIGatewayV2HTTPEvent`
 * `APIGatewayV2HTTPResponse`
 * `APIGatewayV2WebSocketEvent`
@@ -31,6 +33,7 @@
 * `S3Event`
 * `ScheduledEvent`
 * `SecretsManagerRotationEvent`
+* `SimpleIAMPolicyResponse`
 * `SNSEvent`
 * `SQSEvent`
 
@@ -52,7 +55,7 @@
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
     </dependency>
     ...
 </dependencies>
@@ -62,19 +65,19 @@
 
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
-'com.amazonaws:aws-lambda-java-events:3.3.1'
+'com.amazonaws:aws-lambda-java-events:3.4.0'
 ```
 
 [Leiningen](http://leiningen.org) and [Boot](http://boot-clj.com)
 
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
-[com.amazonaws/aws-lambda-java-events "3.3.1"]
+[com.amazonaws/aws-lambda-java-events "3.4.0"]
 ```
 
 [sbt](http://www.scala-sbt.org)
 
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
-"com.amazonaws" % "aws-lambda-java-events" % "3.3.1"
+"com.amazonaws" % "aws-lambda-java-events" % "3.4.0"
 ```

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,3 +1,11 @@
+### October 07, 2020
+`3.4.0`:
+- Added Lambda and IAM authorizers to `APIGatewayV2HTTPEvent` request context ([#167](https://github.com/aws/aws-lambda-java-libs/pull/167))
+- Added support for API Gateway custom authorizer: ([#166](https://github.com/aws/aws-lambda-java-libs/pull/166))
+  - `APIGatewayCustomAuthorizerEvent`
+  - `APIGatewayV2CustomAuthorizerEvent`
+  - `SimpleIAMPolicyResponse`
+
 ### September 23, 2020
 `3.3.1`:
 - Added `multiValueQueryStringParameters` to `ApplicationLoadBalancerRequestEvent` ([#163](https://github.com/aws/aws-lambda-java-libs/pull/163))

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events</artifactId>
-  <version>3.3.1</version>
+  <version>3.4.0</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events Library</name>


### PR DESCRIPTION
**Description of changes:**

Pre-release changes for:
- `aws-lambda-java-events` to `3.4.0`
- `aws-lambda-java-events-sdk-transformer` to `2.0.6`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
