### PR TITLE
removed unnecessary usage of `public` on interface methods

### DIFF
--- a/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/Client.java
+++ b/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/Client.java
@@ -11,28 +11,28 @@ public interface Client {
     /**
     * Gets the application's installation id
     */
-    public String getInstallationId();
+    String getInstallationId();
 
     /**
      * Gets the application's title
      *  
      */
-    public String getAppTitle();
+    String getAppTitle();
 
     /**
      * Gets the application's version
      *  
      */
-    public String getAppVersionName();
+    String getAppVersionName();
 
     /**
      * Gets the application's version code
      *  
      */
-    public String getAppVersionCode();
+    String getAppVersionCode();
 
     /**
      * Gets the application's package name
      */
-    public String getAppPackageName();
+    String getAppPackageName();
 }

--- a/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/ClientContext.java
+++ b/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/ClientContext.java
@@ -14,7 +14,7 @@ public interface ClientContext {
      * Gets the client information provided by the AWS Mobile SDK
      * 
      */
-    public Client getClient();
+    Client getClient();
 
     /**
      * Gets custom values set by the client application
@@ -22,12 +22,12 @@ public interface ClientContext {
      * This map is mutable (and not thread-safe if mutated)
      * </p>
      */
-    public Map<String, String> getCustom();
+    Map<String, String> getCustom();
  
     /**
      * Gets environment information provided by mobile SDK, immutable. 
      * 
      */
-    public Map<String, String> getEnvironment();
+    Map<String, String> getEnvironment();
 
 }

--- a/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/CognitoIdentity.java
+++ b/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/CognitoIdentity.java
@@ -11,11 +11,11 @@ public interface CognitoIdentity {
      * Gets the Amazon Cognito identity ID
      * 
      */
-    public String getIdentityId();
+    String getIdentityId();
 
     /**
      * Gets the Amazon Cognito identity pool ID
      * 
      */
-    public String getIdentityPoolId();
+    String getIdentityPoolId();
 }

--- a/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/LambdaLogger.java
+++ b/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/LambdaLogger.java
@@ -25,12 +25,12 @@ public interface LambdaLogger {
     * 
     * @param message A string containing the event to log.
     */
-    public void log(String message);
+    void log(String message);
 
     /**
      * Logs a byte array to AWS CloudWatch Logs
      * @param message byte array containing logs
      */
-    public void log(byte[] message);
+    void log(byte[] message);
 }
 

--- a/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/RequestHandler.java
+++ b/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/RequestHandler.java
@@ -17,5 +17,5 @@ public interface RequestHandler<I, O> {
      * @param context The Lambda execution environment context object.
      * @return The Lambda Function output
      */
-    public O handleRequest(I input, Context context);
+    O handleRequest(I input, Context context);
 }

--- a/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/RequestStreamHandler.java
+++ b/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/RequestStreamHandler.java
@@ -18,5 +18,5 @@ public interface RequestStreamHandler {
      * @param context The Lambda execution environment context object.
      * @throws IOException
      */
-    public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException;
+    void handleRequest(InputStream input, OutputStream output, Context context) throws IOException;
 }


### PR DESCRIPTION
Based on the definition of an Interface (https://docs.oracle.com/javase/tutorial/java/IandI/interfaceDef.html), the `public` modifier can be omitted.

@bmoffatt 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
