### PR TITLE
feat: EventBridgeEvent

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/EventBridgeEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/EventBridgeEvent.java
@@ -1,0 +1,13 @@
+package com.amazonaws.services.lambda.runtime.events;
+
+/**
+ * Class to represent the EventBridge event. This is also the CloudWatch Events event format.
+ *
+ * This is a duplicate of ScheduledEvent because EventBridge currently share the same schema.
+ *
+ * @see <a href="https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents.html">CloudWatch Events</a>
+ */
+
+public class EventBridgeEvent extends ScheduledEvent {
+
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-java-libs/issues/109

*Description of changes:*
I've made an EventBridgeEvent which is a duplicate of ScheduledEvent, since they're the same schema.

What do you think to this approach, I don't think it'll require any changes to the Lambda service.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
