### PR TITLE
Stage events 3.6.0 and sdk-transformer 2.0.8

### DIFF
--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -16,12 +16,12 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-        <version>2.0.7</version>
+        <version>2.0.8</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0</version>
     </dependency>
 </dependencies>
 ```

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,8 @@
+### November 06, 2020
+`2.0.8`:
+- Bumped `aws-lambda-java-events` to version `3.6.0`
+- Bumped `junit-jupiter-engine` to version `5.7.0`
+
 ### October 28, 2020
 `2.0.7`:
 - Bumped `aws-lambda-java-events` to version `3.5.0`

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>2.0.7</version>
+  <version>2.0.8</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events SDK Transformer Library</name>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>3.5.0</version>
+      <version>3.6.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.6.2</version>
+      <version>5.7.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/aws-lambda-java-events/README.md
+++ b/aws-lambda-java-events/README.md
@@ -1,6 +1,7 @@
 # AWS Lambda Java Events v3
 
 ### Event Models Supported
+* `ActiveMQEvent`
 * `APIGatewayCustomAuthorizerEvent`
 * `APIGatewayProxyRequestEvent`
 * `APIGatewayProxyResponseEvent`
@@ -57,7 +58,7 @@
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0</version>
     </dependency>
     ...
 </dependencies>
@@ -67,19 +68,19 @@
 
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
-'com.amazonaws:aws-lambda-java-events:3.5.0'
+'com.amazonaws:aws-lambda-java-events:3.6.0'
 ```
 
 [Leiningen](http://leiningen.org) and [Boot](http://boot-clj.com)
 
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
-[com.amazonaws/aws-lambda-java-events "3.5.0"]
+[com.amazonaws/aws-lambda-java-events "3.6.0"]
 ```
 
 [sbt](http://www.scala-sbt.org)
 
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
-"com.amazonaws" % "aws-lambda-java-events" % "3.5.0"
+"com.amazonaws" % "aws-lambda-java-events" % "3.6.0"
 ```

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,3 +1,9 @@
+### November 06, 2020
+`3.6.0`:
+- Added support for Amazon `ActiveMQ` event: ([#185](https://github.com/aws/aws-lambda-java-libs/pull/185))
+- Bumped `junit-jupiter-engine` to version `5.7.0`
+- Bumped `lombok` to version `1.18.16`
+
 ### October 28, 2020
 `3.5.0`:
 - Added support for S3 Batch events: ([#179](https://github.com/aws/aws-lambda-java-libs/pull/179))

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -53,13 +53,13 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.5.2</version>
+      <version>5.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.12</version>
+      <version>1.18.16</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events</artifactId>
-  <version>3.5.0</version>
+  <version>3.6.0</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events Library</name>


### PR DESCRIPTION
**Description of changes:**

Pre-release changes for:
- `aws-lambda-java-events` to `3.6.0`
- `aws-lambda-java-events-sdk-transformer` to `2.0.8`

Chore:
- Update `lombok` to `1.18.16`
- Update `junit-jupiter-engine` to `5.7.0`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
