### PR TITLE
Use the absolute path of the java executable in runtime-interface-cli…

### DIFF
--- a/aws-lambda-java-runtime-interface-client/README.md
+++ b/aws-lambda-java-runtime-interface-client/README.md
@@ -47,7 +47,7 @@ COPY --from=build /src/target/dependency/*.jar ./
 COPY --from=build /src/target/*.jar ./
 
 # configure the runtime startup as main
-ENTRYPOINT [ "java", "-cp", "./*", "com.amazonaws.services.lambda.runtime.api.client.AWSLambda" ]
+ENTRYPOINT [ "/usr/bin/java", "-cp", "./*", "com.amazonaws.services.lambda.runtime.api.client.AWSLambda" ]
 # pass the name of the function handler as an argument to the runtime
 CMD [ "example.App::sayHello" ]
 ```


### PR DESCRIPTION
…ent example

*Issue #, if available:*

*Description of changes:*

Fix runtime-interface-client example's Dockerfile in README.md.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
