### PR TITLE
Include RIC pr target in GitHub action

### DIFF
--- a/.github/workflows/maven-build-all.yml
+++ b/.github/workflows/maven-build-all.yml
@@ -31,7 +31,8 @@ jobs:
       run: mvn -B package --file aws-lambda-java-events-sdk-transformer/pom.xml
     - name: Build log4j2 with Maven
       run: mvn -B package --file aws-lambda-java-log4j2/pom.xml
-    - name: Build serialization with Maven
-      run: mvn -B package --file aws-lambda-java-serialization/pom.xml
-    - name: Build runtime-interface-client with Maven
-      run: mvn -B package --file aws-lambda-java-runtime-interface-client/pom.xml
+
+    # Test Runtime Interface Client
+    - name: Run 'pr' target
+      working-directory: ./aws-lambda-java-runtime-interface-client
+      run: make pr

--- a/aws-lambda-java-runtime-interface-client/README.md
+++ b/aws-lambda-java-runtime-interface-client/README.md
@@ -15,7 +15,7 @@ Choose a preferred base image. The Runtime Interface Client is tested on Amazon 
 
 * built for x86_64
 * contains Java >= 8
-* contains glibc >= 2.12 or musl
+* contains glibc >= 2.17 or musl
 
 ### Example
 

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/Dockerfile.glibc
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/Dockerfile.glibc
@@ -1,10 +1,11 @@
-# we use centos 6 to build against glibc 2.12
-FROM centos:6
+# we use centos 7 to build against glibc 2.12
+FROM centos:7
 
 # aws-lambda-cpp requires cmake3, it's available in EPEL
 RUN yum install -y epel-release
 RUN yum install -y \
     cmake3 \
+    make \
     gcc \
     gcc-c++ \
     glibc-devel \

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/Dockerfile.glibc
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/Dockerfile.glibc
@@ -1,4 +1,4 @@
-# we use centos 7 to build against glibc 2.12
+# we use centos 7 to build against glibc 2.17
 FROM centos:7
 
 # aws-lambda-cpp requires cmake3, it's available in EPEL

--- a/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoaderTest.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoaderTest.java
@@ -95,24 +95,35 @@ public class CustomerClassLoaderTest {
     @Test
     @DisabledOnOs(MAC) // test fails on systems with case-insensitive volumes
     public void customerClassLoaderFunction() throws IOException {
-        Path rootDir = fakeFileSystem(EXAMPLE_FUNCTION);
+        try {
+            Path rootDir = fakeFileSystem(EXAMPLE_FUNCTION);
 
-        URLClassLoader customerClassLoader = new CustomerClassLoader(
-                rootDir.resolve("user/path").toString(),
-                rootDir.resolve("opt/java").toString(),
-                ClassLoader.getSystemClassLoader());
+            URLClassLoader customerClassLoader = new CustomerClassLoader(
+                    rootDir.resolve("user/path").toString(),
+                    rootDir.resolve("opt/java").toString(),
+                    ClassLoader.getSystemClassLoader());
 
-        List<String> res = strip("file:" + rootDir.toString(), customerClassLoader.getURLs());
+            List<String> res = strip("file:" + rootDir.toString(), customerClassLoader.getURLs());
 
-        Assertions.assertEquals(Arrays.asList(
-                "/user/path/",
-                "/user/path/lib/4.jar",
-                "/user/path/lib/A.jar",
-                "/user/path/lib/a.jar",
-                "/user/path/lib/b.jar",
-                "/user/path/lib/z.jar",
-                "/user/path/lib/λ.jar"),
-                res);
+            Assertions.assertEquals(Arrays.asList(
+                    "/user/path/",
+                    "/user/path/lib/4.jar",
+                    "/user/path/lib/A.jar",
+                    "/user/path/lib/a.jar",
+                    "/user/path/lib/b.jar",
+                    "/user/path/lib/z.jar",
+                    "/user/path/lib/λ.jar"),
+                    res);
+        } catch(Throwable t) {
+            // this system property is the name of the charset used when encoding/decoding file paths
+            // exception is expected if it is not set to a UTF variant
+            if (!System.getProperty("sun.jnu.encoding").toLowerCase().contains("utf")){
+                Assertions.assertTrue(t.getMessage().contains("Malformed input or input contains unmappable characters"));
+            }
+            else {
+                throw t;
+            }
+        }
     }
 
     @Test

--- a/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoaderTest.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoaderTest.java
@@ -116,8 +116,10 @@ public class CustomerClassLoaderTest {
                     res);
         } catch(Throwable t) {
             // this system property is the name of the charset used when encoding/decoding file paths
-            // exception is expected if it is not set to a UTF variant
-            if (!System.getProperty("sun.jnu.encoding").toLowerCase().contains("utf")){
+            // exception is expected if it is not set to a UTF variant or not set at all
+            String systemEncoding = System.getProperty("sun.jnu.encoding");
+
+            if (systemEncoding != null && !systemEncoding.toLowerCase().contains("utf")){
                 Assertions.assertTrue(t.getMessage().contains("Malformed input or input contains unmappable characters"));
             }
             else {

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/codebuild_build.sh
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/codebuild_build.sh
@@ -95,7 +95,7 @@ then
     exit 1
 fi
 
-docker_command="docker run -it "
+docker_command="docker run "
 if isOSWindows
 then
     docker_command+="-v //var/run/docker.sock:/var/run/docker.sock -e "

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.centos.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.centos.yml
@@ -15,7 +15,6 @@ batch:
       env:
         variables:
           DISTRO_VERSION:
-            - "6"
             - "7"
             - "8"
           RUNTIME_VERSION:


### PR DESCRIPTION
*Description of changes:*
- Included RIC `pr` target in GitHub action and removed the building commands that were already there since the `pr` target would also build them and would generate conflicts
- Removed unnecessary -it option from codebuild_build.sh because it was causing tty error when running the GitHub action
- Refactored a test that uses a special character to expect failure if the encoding is not set to UTF
- Updated to CentOS:7
- Removed CentOS:6 from the OS compatibility test since it reached EOL

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
