### PR TITLE
Stop building gcc from source

### DIFF
--- a/aws-lambda-java-runtime-interface-client/Makefile
+++ b/aws-lambda-java-runtime-interface-client/Makefile
@@ -14,6 +14,7 @@ setup-codebuild-agent:
 .PHONY: test-smoke
 test-smoke: setup-codebuild-agent
 	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.alpine.yml alpine 3.12 corretto11
+	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.amazoncorretto.yml amazoncorretto amazoncorretto 11
 
 .PHONY: test-integ
 test-integ: setup-codebuild-agent

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/Dockerfile.glibc
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/Dockerfile.glibc
@@ -1,41 +1,27 @@
 # we use centos 7 to build against glibc 2.17
 FROM centos:7
 
+# Add Corretto repository
+RUN rpm --import https://yum.corretto.aws/corretto.key && \
+    curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
+
 # aws-lambda-cpp requires cmake3, it's available in EPEL
 RUN yum install -y epel-release
 RUN yum install -y \
-    cmake3 \
-    make \
-    gcc \
-    gcc-c++ \
-    glibc-devel \
-    gmp-devel \
-    libmpc-devel \
-    libtool \
-    mpfr-devel \
-    wget
+        cmake3 \
+        make \
+        gcc \
+        gcc-c++ \
+        libstdc++-static \
+        glibc-devel \
+        gmp-devel \
+        libmpc-devel \
+        libtool \
+        mpfr-devel \
+        wget \
+        java-1.8.0-amazon-corretto-devel
 
-# aws-lambda-cpp also needs a newer compiler than the default gcc 4.4
-ARG GCC_VERSION=4.8.5
-RUN wget -qO- https://mirrors.kernel.org/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.gz | tar xzf -
-WORKDIR gcc-$GCC_VERSION
-RUN ./configure \
-       --disable-multilib \
-       --enable-languages=c,c++ && \
-    make -j$(nproc) && \
-    make install
-RUN yum remove -y gcc gcc-c++
-RUN rm -rf /usr/bin/gcc && \
-    rm -rf /usr/bin/c++ && \
-    rm -rf /usr/bin/cc && \
-    ln -s /usr/local/bin/x86_64-unknown-linux-gnu-gcc-$GCC_VERSION /usr/bin/gcc && \
-    ln -s /usr/local/bin/x86_64-unknown-linux-gnu-c++ /usr/bin/c++ && \
-    ln -s /usr/local/bin/x86_64-unknown-linux-gnu-gcc /usr/bin/cc
-
-RUN rpm --import https://yum.corretto.aws/corretto.key
-RUN curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo
-RUN yum install -y java-1.8.0-amazon-corretto-devel
-
+# Install curl dependency
 ADD ./deps/curl-* /src/deps/curl
 WORKDIR /src/deps/curl
 RUN ./configure \
@@ -46,6 +32,7 @@ RUN ./configure \
     make && \
     make install
 
+# Install aws-lambda-cpp dependency
 ADD ./deps/aws-lambda-cpp-* /src/deps/aws-lambda-cpp
 RUN sed -i.bak 's/VERSION 3.9/VERSION 3.6/' /src/deps/aws-lambda-cpp/CMakeLists.txt
 RUN mkdir -p /src/deps/aws-lambda-cpp/build
@@ -54,11 +41,12 @@ RUN cmake3 .. \
         -DENABLE_LTO=OFF \
         -DCMAKE_CXX_FLAGS="-fPIC -DBACKWARD_SYSTEM_UNKNOWN" \
         -DCMAKE_CXX_STANDARD=11 \
-        -DCMAKE_INSTALL_PREFIX=$(pwd)/../../artifacts\
+        -DCMAKE_INSTALL_PREFIX=$(pwd)/../../artifacts \
         -DCMAKE_MODULE_PATH=$(pwd)/../../artifacts/lib/pkgconfig && \
     make && \
     make install
 
+# Build native client
 ADD *.cpp *.h /src/
 WORKDIR /src
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/Dockerfile.musl
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/Dockerfile.musl
@@ -1,17 +1,21 @@
 FROM alpine:3
-RUN wget -O /etc/apk/keys/amazoncorretto.rsa.pub  https://apk.corretto.aws/amazoncorretto.rsa.pub
-RUN echo "https://apk.corretto.aws/" >> /etc/apk/repositories
-RUN apk update
-RUN apk add \
-    amazon-corretto-8 \
-    cmake \
-    file \
-    g++ \
-    gcc \
-    make \
-    libexecinfo-dev \
-    perl
 
+# Add Corretto repository
+RUN wget -O /etc/apk/keys/amazoncorretto.rsa.pub  https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    echo "https://apk.corretto.aws/" >> /etc/apk/repositories
+
+RUN apk update && \
+    apk add \
+        amazon-corretto-8 \
+        cmake \
+        file \
+        g++ \
+        gcc \
+        make \
+        libexecinfo-dev \
+        perl
+
+# Install curl dependency
 ADD ./deps/curl-* /src/deps/curl
 WORKDIR /src/deps/curl
 RUN ./configure \
@@ -22,6 +26,7 @@ RUN ./configure \
     make && \
     make install
 
+# Install aws-lambda-cpp dependency
 ADD ./deps/aws-lambda-cpp-* /src/deps/aws-lambda-cpp
 RUN mkdir -p /src/deps/aws-lambda-cpp/build
 WORKDIR /src/deps/aws-lambda-cpp/build
@@ -33,6 +38,7 @@ RUN cmake .. \
     make && \
     make install
 
+# Build native client
 ADD *.cpp *.h /src/
 WORKDIR /src
 ENV JAVA_HOME=/usr/lib/jvm/java-8-amazon-corretto

--- a/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoaderTest.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoaderTest.java
@@ -2,9 +2,7 @@
 
 package com.amazonaws.services.lambda.runtime.api.client;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
@@ -20,18 +18,6 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.condition.OS.MAC;
 
 public class CustomerClassLoaderTest {
-    private static final String USER_WORKING_DIR = "user/path";
-    private static final String ORIGINAL_WORKING_DIR = System.getProperty("user.dir");
-
-    @BeforeEach
-    public void before() {
-        System.setProperty("user.dir", USER_WORKING_DIR);
-    }
-
-    @AfterEach
-    public void after() {
-        System.setProperty("user.dir", ORIGINAL_WORKING_DIR);
-    }
 
     final static String[] EXAMPLE_FUNCTION = new String[]{
             "var/runtime/lib/LambdaJavaRTEntry-1.0.jar",


### PR DESCRIPTION
*Description of changes:*
This PR:
- Changes the RIC's build process to use gcc from `yum` as opposed to building it from source (as it's now a modern supported version after updating to CentOS 7 done [here](https://github.com/aws/aws-lambda-java-libs/pull/193))
- Removes unnecessary `user.dir` overrides in `CustomerClassLoaderTest`
- Adds glibc OS test in test-smoke (now also testing `amazoncorretto` version `11` - previously we were only testing Alpine with musl)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
