### PR TITLE
Add SDK v1 transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>2.0.8</version>
+  <version>3.0.0</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
@@ -60,7 +60,7 @@ ___
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
 'com.amazonaws:aws-lambda-java-events:3.6.0'
-'com.amazonaws:aws-lambda-java-events-sdk-transformer:2.0.8'
+'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.0'
 'com.amazonaws:aws-lambda-java-log4j2:1.2.0'
 'com.amazonaws:aws-lambda-java-runtime-interface-client:1.0.0'
 ```
@@ -70,7 +70,7 @@ ___
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
 [com.amazonaws/aws-lambda-java-events "3.6.0"]
-[com.amazonaws/aws-lambda-java-events-sdk-transformer "2.0.8"]
+[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.0"]
 [com.amazonaws/aws-lambda-java-log4j2 "1.2.0"]
 [com.amazonaws/aws-lambda-java-runtime-interface-client "1.0.0"]
 ```
@@ -80,7 +80,7 @@ ___
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
 "com.amazonaws" % "aws-lambda-java-events" % "3.6.0"
-"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "2.0.8"
+"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.0"
 "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0"
 "com.amazonaws" % "aws-lambda-java-runtime-interface-client" % "1.0.0"
 ```

--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -4,7 +4,7 @@
 
 Provides helper classes/methods to use alongside `aws-lambda-java-events` in order to transform Lambda input event model
  objects into SDK-compatible output model objects 
- (eg. DynamodbEvent to a List of records writable back to DynamoDB through the AWS DynamoDB SDK v2).
+ (eg. DynamodbEvent to a List of records writable back to DynamoDB through the AWS DynamoDB SDK for Java v1 or v2).
  
 
 ### Getting started
@@ -16,7 +16,7 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-        <version>2.0.8</version>
+        <version>3.0.0</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>
@@ -33,7 +33,19 @@ To use this library as a transformer to the AWS DynamoDB Java SDK v2, also add t
     <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>dynamodb</artifactId>
-        <version>2.13.18</version>
+        <version>2.15.40</version>
+    </dependency>
+</dependencies>
+```
+
+To use this library as a transformer to the AWS DynamoDB Java SDK v1, add the following dependency to your `pom.xml` file instead:
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-dynamodb</artifactId>
+        <version>1.11.914</version>
     </dependency>
 </dependencies>
 ```
@@ -41,75 +53,162 @@ To use this library as a transformer to the AWS DynamoDB Java SDK v2, also add t
 
 ### Example Usage
 
+#### SDK v2
+
 To convert a full `DynamodbEvent` object to an SDK v2 compatible `List<Record>`:
+
 ```java
-import com.amazonaws.services.lambda.runtime.events.transformers.DynamodbEventTransformer;
+import com.amazonaws.services.lambda.runtime.events.transformers.v2.DynamodbEventTransformer;
 
 public class DDBEventProcessor implements RequestHandler<DynamodbEvent, String> {
 
-    public String handleRequest(DynamodbEvent ddbEvent, Context context) {
-        // Process input event
-        List<Record> convertedRecords = DynamodbEventTransformer.toRecordsV2(ddbEvent);
-        // Modify records as needed and write back to DynamoDB using the DynamoDB AWS SDK for Java 2.0
-    }
+ public String handleRequest(DynamodbEvent ddbEvent, Context context) {
+  // Process input event
+  List<Record> convertedRecords = DynamodbEventTransformer.toRecordsV2(ddbEvent);
+  // Modify records as needed and write back to DynamoDB using the DynamoDB AWS SDK for Java 2.0
+ }
 }
 ```
 
 To convert a single `DynamodbEvent.DynamodbStreamRecord` object to an SDK v2 compatible `Record`:
+
 ```java
-import com.amazonaws.services.lambda.runtime.events.transformers.dynamodb.DynamodbRecordTransformer;
+import com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbRecordTransformer;
 
 public class MyClass {
 
-    public void myMethod(DynamodbEvent.DynamodbStreamRecord record) {
-        // ...
-        Record convertedRecord = DynamodbRecordTransformer.toRecordV2(record);
-        // ...
-    }
+ public void myMethod(DynamodbEvent.DynamodbStreamRecord record) {
+  // ...
+  Record convertedRecord = DynamodbRecordTransformer.toRecordV2(record);
+  // ...
+ }
 }
 ```
 
 To convert a `StreamRecord` object originating from a `DynamodbEvent` to an SDK v2 compatible `StreamRecord`:
+
 ```java
-import com.amazonaws.services.lambda.runtime.events.transformers.dynamodb.DynamodbStreamRecordTransformer;
+import com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbStreamRecordTransformer;
 
 public class MyClass {
 
-    public void myMethod(StreamRecord streamRecord) {
-        // ...
-        software.amazon.awssdk.services.dynamodb.model.StreamRecord convertedStreamRecord = 
-                DynamodbStreamRecordTransformer.toStreamRecordV2(streamRecord);
-        // ...
-    }
+ public void myMethod(StreamRecord streamRecord) {
+  // ...
+  software.amazon.awssdk.services.dynamodb.model.StreamRecord convertedStreamRecord =
+          DynamodbStreamRecordTransformer.toStreamRecordV2(streamRecord);
+  // ...
+ }
 }
 ```
 
 To convert an `AttributeValue` object originating from a `DynamodbEvent` to an SDK v2 compatible `AttributeValue`:
+
 ```java
-import com.amazonaws.services.lambda.runtime.events.transformers.dynamodb.DynamodbAttributeValueTransformer;
+import com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformer;
 
 public class MyClass {
 
-    public void myMethod(AttributeValue attributeValue) {
-        // ...
-        software.amazon.awssdk.services.dynamodb.model.AttributeValue convertedAttributeValue = 
-                DynamodbAttributeValueTransformer.toAttributeValueV2(attributeValue);
-        // ...
-    }
+ public void myMethod(AttributeValue attributeValue) {
+  // ...
+  software.amazon.awssdk.services.dynamodb.model.AttributeValue convertedAttributeValue =
+          DynamodbAttributeValueTransformer.toAttributeValueV2(attributeValue);
+  // ...
+ }
 }
 ```
 
 To convert an `Identity` object originating from a `DynamodbEvent` to an SDK v2 compatible `Identity`:
+
 ```java
-import com.amazonaws.services.lambda.runtime.events.transformers.dynamodb.DynamodbIdentityTransformer;
+import com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbIdentityTransformer;
 
 public class MyClass {
 
-    public void myMethod(Identity identity) {
-        // ...
-        software.amazon.awssdk.services.dynamodb.model.Identity convertedIdentity =
-                DynamodbIdentityTransformer.toIdentityV2(identity);
-        // ...
-    }
+ public void myMethod(Identity identity) {
+  // ...
+  software.amazon.awssdk.services.dynamodb.model.Identity convertedIdentity =
+          DynamodbIdentityTransformer.toIdentityV2(identity);
+  // ...
+ }
+}
+```
+
+#### SDK v1
+
+To convert a full `DynamodbEvent` object to an SDK v1 compatible `List<Record>`:
+
+```java
+import com.amazonaws.services.lambda.runtime.events.transformers.v1.DynamodbEventTransformer;
+
+public class DDBEventProcessor implements RequestHandler<DynamodbEvent, String> {
+
+ public String handleRequest(DynamodbEvent ddbEvent, Context context) {
+  // Process input event
+  List<Record> convertedRecords = DynamodbEventTransformer.toRecordsV1(ddbEvent);
+  // Modify records as needed and write back to DynamoDB using the DynamoDB AWS SDK for Java 2.0
+ }
+}
+```
+
+To convert a single `DynamodbEvent.DynamodbStreamRecord` object to an SDK v1 compatible `Record`:
+
+```java
+import com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbRecordTransformer;
+
+public class MyClass {
+
+ public void myMethod(DynamodbEvent.DynamodbStreamRecord record) {
+  // ...
+  Record convertedRecord = DynamodbRecordTransformer.toRecordV1(record);
+  // ...
+ }
+}
+```
+
+To convert a `StreamRecord` object originating from a `DynamodbEvent` to an SDK v1 compatible `StreamRecord`:
+
+```java
+import com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbStreamRecordTransformer;
+
+public class MyClass {
+
+ public void myMethod(StreamRecord streamRecord) {
+  // ...
+  com.amazonaws.services.dynamodbv2.model.StreamRecord convertedStreamRecord =
+          DynamodbStreamRecordTransformer.toStreamRecordV1(streamRecord);
+  // ...
+ }
+}
+```
+
+To convert an `AttributeValue` object originating from a `DynamodbEvent` to an SDK v1 compatible `AttributeValue`:
+
+```java
+import com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformer;
+
+public class MyClass {
+
+ public void myMethod(AttributeValue attributeValue) {
+  // ...
+  com.amazonaws.services.dynamodbv2.model.AttributeValue convertedAttributeValue =
+          DynamodbAttributeValueTransformer.toAttributeValueV1(attributeValue);
+  // ...
+ }
+}
+```
+
+To convert an `Identity` object originating from a `DynamodbEvent` to an SDK v1 compatible `Identity`:
+
+```java
+import com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbIdentityTransformer;
+
+public class MyClass {
+
+ public void myMethod(Identity identity) {
+  // ...
+  com.amazonaws.services.dynamodbv2.model.Identity convertedIdentity =
+          DynamodbIdentityTransformer.toIdentityV1(identity);
+  // ...
+ }
 }
 ```

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,9 @@
+### Upcoming
+`3.0.0`:
+- Added AWS SDK V1 transformers for `DynamodbEvent` in `aws-lambda-java-events` versions `3.0.0` and up
+- Moved existing SDK v2 transformers into `v2` package (from `com.amazonaws.services.lambda.runtime.events.transformers` to `com.amazonaws.services.lambda.runtime.events.transformers.v2`)
+- Bumped `software.amazon.awssdk:dynamodb` to version `2.15.40`
+
 ### November 06, 2020
 `2.0.8`:
 - Bumped `aws-lambda-java-events` to version `3.6.0`

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -5,14 +5,14 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>2.0.8</version>
+  <version>3.0.0</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events SDK Transformer Library</name>
   <description>
     Provides helper classes/methods to use alongside aws-lambda-java-events in order to transform Lambda input event model
     objects into SDK-compatible output model objects (eg. DynamodbEvent to a List of records writable back to DynamoDB
-    through the AWS DynamoDB SDK v2)
+    through the AWS DynamoDB SDK for Java v1 or v2)
   </description>
   <url>https://aws.amazon.com/lambda/</url>
   <licenses>
@@ -36,6 +36,8 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <sdk.v1.version>1.11.914</sdk.v1.version>
+    <sdk.v2.version>2.15.40</sdk.v2.version>
   </properties>
 
   <distributionManagement>
@@ -49,7 +51,13 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>dynamodb</artifactId>
-      <version>2.13.18</version>
+      <version>${sdk.v2.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-dynamodb</artifactId>
+      <version>${sdk.v1.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/DynamodbEventTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/DynamodbEventTransformer.java
@@ -1,0 +1,21 @@
+package com.amazonaws.services.lambda.runtime.events.transformers.v1;
+
+import com.amazonaws.services.dynamodbv2.model.Record;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbRecordTransformer;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class DynamodbEventTransformer {
+
+    public static List<Record> toRecordsV1(final DynamodbEvent dynamodbEvent) {
+        return dynamodbEvent
+                .getRecords()
+                .stream()
+                .filter(record -> !Objects.isNull(record))
+                .map(DynamodbRecordTransformer::toRecordV1)
+                .collect(Collectors.toList());
+    }
+}

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformer.java
@@ -1,0 +1,73 @@
+package com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class DynamodbAttributeValueTransformer {
+
+    public static AttributeValue toAttributeValueV1(final com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue value) {
+        if (Objects.nonNull(value.getS())) {
+            return new AttributeValue()
+                    .withS(value.getS());
+
+        } else if (Objects.nonNull(value.getSS())) {
+            return new AttributeValue()
+                    .withSS(value.getSS().isEmpty() ? null : value.getSS());
+
+        } else if (Objects.nonNull(value.getN())) {
+            return new AttributeValue()
+                    .withN(value.getN());
+
+        } else if (Objects.nonNull(value.getNS())) {
+            return new AttributeValue()
+                    .withNS(value.getNS().isEmpty() ? null : value.getNS());
+
+        } else if (Objects.nonNull(value.getB())) {
+            return new AttributeValue()
+                    .withB(value.getB());
+
+        } else if (Objects.nonNull(value.getBS())) {
+            return new AttributeValue()
+                    .withBS(value.getBS().isEmpty() ? null : value.getBS());
+
+        } else if (Objects.nonNull(value.getBOOL())) {
+            return new AttributeValue()
+                    .withBOOL(value.getBOOL());
+
+        } else if (Objects.nonNull(value.getL())) {
+            return new AttributeValue()
+                    .withL(value.getL().isEmpty()
+                            ? null
+                            : value.getL().stream()
+                                .map(DynamodbAttributeValueTransformer::toAttributeValueV1)
+                                .collect(Collectors.toList()));
+
+        } else if (Objects.nonNull(value.getM())) {
+            return new AttributeValue()
+                    .withM(toAttributeValueMapV1(value.getM()));
+
+        } else if (Objects.nonNull(value.getNULL())) {
+            return new AttributeValue()
+                    .withNULL(value.getNULL());
+
+        } else {
+            throw new IllegalArgumentException(
+                    String.format("Unsupported attributeValue type: %s", value));
+        }
+    }
+
+    static Map<String, AttributeValue> toAttributeValueMapV1(
+            final Map<String, com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue> attributeValueMap
+    ) {
+        return attributeValueMap
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> toAttributeValueV1(entry.getValue())
+                ));
+    }
+}

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbIdentityTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbIdentityTransformer.java
@@ -1,0 +1,12 @@
+package com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.model.Identity;
+
+public class DynamodbIdentityTransformer {
+
+    public static Identity toIdentityV1(final com.amazonaws.services.lambda.runtime.events.models.dynamodb.Identity identity) {
+        return new Identity()
+                .withPrincipalId(identity.getPrincipalId())
+                .withType(identity.getType());
+    }
+}

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbRecordTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbRecordTransformer.java
@@ -1,0 +1,22 @@
+package com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.model.Record;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+
+public class DynamodbRecordTransformer {
+
+    public static Record toRecordV1(final DynamodbEvent.DynamodbStreamRecord record) {
+        return new Record()
+                .withAwsRegion(record.getAwsRegion())
+                .withDynamodb(
+                        DynamodbStreamRecordTransformer.toStreamRecordV1(record.getDynamodb())
+                )
+                .withEventID(record.getEventID())
+                .withEventName(record.getEventName())
+                .withEventSource(record.getEventSource())
+                .withEventVersion(record.getEventVersion())
+                .withUserIdentity(
+                        DynamodbIdentityTransformer.toIdentityV1(record.getUserIdentity())
+                );
+    }
+}

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbStreamRecordTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbStreamRecordTransformer.java
@@ -1,0 +1,25 @@
+package com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.model.StreamRecord;
+
+public class DynamodbStreamRecordTransformer {
+
+    public static StreamRecord toStreamRecordV1(final com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord streamRecord) {
+        return new StreamRecord()
+                .withApproximateCreationDateTime(
+                        streamRecord.getApproximateCreationDateTime()
+                )
+                .withKeys(
+                        DynamodbAttributeValueTransformer.toAttributeValueMapV1(streamRecord.getKeys())
+                )
+                .withNewImage(
+                        DynamodbAttributeValueTransformer.toAttributeValueMapV1(streamRecord.getNewImage())
+                )
+                .withOldImage(
+                        DynamodbAttributeValueTransformer.toAttributeValueMapV1(streamRecord.getOldImage())
+                )
+                .withSequenceNumber(streamRecord.getSequenceNumber())
+                .withSizeBytes(streamRecord.getSizeBytes())
+                .withStreamViewType(streamRecord.getStreamViewType());
+    }
+}

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/DynamodbEventTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/DynamodbEventTransformer.java
@@ -1,7 +1,7 @@
-package com.amazonaws.services.lambda.runtime.events.transformers;
+package com.amazonaws.services.lambda.runtime.events.transformers.v2;
 
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
-import com.amazonaws.services.lambda.runtime.events.transformers.dynamodb.DynamodbRecordTransformer;
+import com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbRecordTransformer;
 import software.amazon.awssdk.services.dynamodb.model.Record;
 
 import java.util.List;

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbAttributeValueTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbAttributeValueTransformer.java
@@ -1,4 +1,4 @@
-package com.amazonaws.services.lambda.runtime.events.transformers.dynamodb;
+package com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb;
 
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -17,7 +17,7 @@ public class DynamodbAttributeValueTransformer {
 
         } else if (Objects.nonNull(value.getSS())) {
             return AttributeValue.builder()
-                    .ss(value.getSS())
+                    .ss(value.getSS().isEmpty() ? null : value.getSS())
                     .build();
 
         } else if (Objects.nonNull(value.getN())) {
@@ -27,7 +27,7 @@ public class DynamodbAttributeValueTransformer {
 
         } else if (Objects.nonNull(value.getNS())) {
             return AttributeValue.builder()
-                    .ns(value.getNS())
+                    .ns(value.getNS().isEmpty() ? null : value.getNS())
                     .build();
 
         } else if (Objects.nonNull(value.getB())) {
@@ -37,9 +37,11 @@ public class DynamodbAttributeValueTransformer {
 
         } else if (Objects.nonNull(value.getBS())) {
             return AttributeValue.builder()
-                    .bs(value.getBS().stream()
-                            .map(SdkBytes::fromByteBuffer)
-                            .collect(Collectors.toList()))
+                    .bs(value.getBS().isEmpty()
+                            ? null
+                            : value.getBS().stream()
+                                .map(SdkBytes::fromByteBuffer)
+                                .collect(Collectors.toList()))
                     .build();
 
         } else if (Objects.nonNull(value.getBOOL())) {
@@ -49,9 +51,11 @@ public class DynamodbAttributeValueTransformer {
 
         } else if (Objects.nonNull(value.getL())) {
             return AttributeValue.builder()
-                    .l(value.getL().stream()
-                            .map(DynamodbAttributeValueTransformer::toAttributeValueV2)
-                            .collect(Collectors.toList()))
+                    .l(value.getL().isEmpty()
+                            ? null
+                            : value.getL().stream()
+                                .map(DynamodbAttributeValueTransformer::toAttributeValueV2)
+                                .collect(Collectors.toList()))
                     .build();
 
         } else if (Objects.nonNull(value.getM())) {

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbIdentityTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbIdentityTransformer.java
@@ -1,4 +1,4 @@
-package com.amazonaws.services.lambda.runtime.events.transformers.dynamodb;
+package com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb;
 
 import software.amazon.awssdk.services.dynamodb.model.Identity;
 

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbRecordTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbRecordTransformer.java
@@ -1,4 +1,4 @@
-package com.amazonaws.services.lambda.runtime.events.transformers.dynamodb;
+package com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb;
 
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
 import software.amazon.awssdk.services.dynamodb.model.Record;

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbStreamRecordTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbStreamRecordTransformer.java
@@ -1,4 +1,4 @@
-package com.amazonaws.services.lambda.runtime.events.transformers.dynamodb;
+package com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb;
 
 import software.amazon.awssdk.services.dynamodb.model.StreamRecord;
 

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/DynamodbEventTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/DynamodbEventTransformerTest.java
@@ -1,31 +1,32 @@
-package com.amazonaws.services.lambda.runtime.events.transformers;
+package com.amazonaws.services.lambda.runtime.events.transformers.v1;
 
+import com.amazonaws.services.dynamodbv2.model.Record;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.services.dynamodb.model.Record;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static com.amazonaws.services.lambda.runtime.events.transformers.dynamodb.DynamodbRecordTransformerTest.record_event;
-import static com.amazonaws.services.lambda.runtime.events.transformers.dynamodb.DynamodbRecordTransformerTest.record_v2;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbRecordTransformerTest.record_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbRecordTransformerTest.record_v1;
 
 public class DynamodbEventTransformerTest {
 
     private final DynamodbEvent dynamodbEvent;
+
     {
         record_event.setEventSourceARN("arn:aws:dynamodb:us-west-2:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899");
         dynamodbEvent = new DynamodbEvent();
         dynamodbEvent.setRecords(Collections.singletonList(record_event));
     }
 
-    private final List<Record> expectedRecordsV2 = Collections.singletonList(record_v2);
+    private final List<Record> expectedRecordsV2 = Collections.singletonList(record_v1);
 
     @Test
     public void testDynamodbEventToRecordsV2() {
-        List<Record> convertedRecords = DynamodbEventTransformer.toRecordsV2(dynamodbEvent);
+        List<Record> convertedRecords = DynamodbEventTransformer.toRecordsV1(dynamodbEvent);
         Assertions.assertEquals(expectedRecordsV2, convertedRecords);
     }
 
@@ -35,7 +36,7 @@ public class DynamodbEventTransformerTest {
         event.setRecords(Arrays.asList(record_event, null));
         Assertions.assertEquals(2, event.getRecords().size());
 
-        List<Record> convertedRecords = DynamodbEventTransformer.toRecordsV2(event);
+        List<Record> convertedRecords = DynamodbEventTransformer.toRecordsV1(event);
         Assertions.assertEquals(expectedRecordsV2, convertedRecords);
         Assertions.assertEquals(1, convertedRecords.size());
     }

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformerTest.java
@@ -1,0 +1,313 @@
+package com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb;
+
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+class DynamodbAttributeValueTransformerTest {
+
+    private static final String valueN = "101";
+    private static final List<String> valueNS = Arrays.asList("1", "2", "3");
+    private static final String valueS = "SVal";
+    private static final List<String> valueSS = Arrays.asList("first", "second", "third");
+    private static final ByteBuffer valueB = ByteBuffer.wrap("BVal".getBytes());
+    private static final List<ByteBuffer> valueBS = Arrays.asList(
+            ByteBuffer.wrap("first".getBytes()),
+            ByteBuffer.wrap("second".getBytes()),
+            ByteBuffer.wrap("third".getBytes()));
+    private static final boolean valueBOOL = true;
+    private static final boolean valueNUL = true;
+
+    private static final String keyM1 = "NestedMapKey1";
+    private static final String keyM2 = "NestedMapKey2";
+
+    //region AttributeValue_event
+    public static final AttributeValue attributeValueN_event = new AttributeValue().withN(valueN);
+    public static final AttributeValue attributeValueNS_event = new AttributeValue().withNS(valueNS);
+    public static final AttributeValue attributeValueS_event = new AttributeValue().withS(valueS);
+    public static final AttributeValue attributeValueSS_event = new AttributeValue().withSS(valueSS);
+    public static final AttributeValue attributeValueB_event = new AttributeValue().withB(valueB);
+    public static final AttributeValue attributeValueBS_event = new AttributeValue().withBS(valueBS);
+    public static final AttributeValue attributeValueBOOL_event = new AttributeValue().withBOOL(valueBOOL);
+    public static final AttributeValue attributeValueNUL_event = new AttributeValue().withNULL(valueNUL);
+    public static final AttributeValue attributeValueM_event = new AttributeValue().withM(new HashMap<String, AttributeValue>() {{
+        put(keyM1, attributeValueN_event);
+        put(keyM2, attributeValueS_event);
+    }});
+    public static final AttributeValue attributeValueL_event = new AttributeValue().withL(Arrays.asList(
+            attributeValueN_event,
+            attributeValueNS_event,
+            attributeValueS_event,
+            attributeValueSS_event,
+            attributeValueB_event,
+            attributeValueBS_event,
+            attributeValueBOOL_event,
+            attributeValueNUL_event,
+            attributeValueM_event,
+            new AttributeValue().withL(Arrays.asList(
+                    attributeValueN_event,
+                    attributeValueNS_event,
+                    attributeValueS_event,
+                    attributeValueSS_event,
+                    attributeValueB_event,
+                    attributeValueBS_event,
+                    attributeValueBOOL_event,
+                    attributeValueNUL_event,
+                    attributeValueM_event
+            ))
+    ));
+    //endregion
+
+    //region AttributeValue_v1
+    public static final com.amazonaws.services.dynamodbv2.model.AttributeValue attributeValueN_v1 =
+            new com.amazonaws.services.dynamodbv2.model.AttributeValue().withN(valueN);
+    public static final com.amazonaws.services.dynamodbv2.model.AttributeValue attributeValueNS_v1 =
+            new com.amazonaws.services.dynamodbv2.model.AttributeValue().withNS(valueNS);
+    public static final com.amazonaws.services.dynamodbv2.model.AttributeValue attributeValueS_v1 =
+            new com.amazonaws.services.dynamodbv2.model.AttributeValue().withS(valueS);
+    public static final com.amazonaws.services.dynamodbv2.model.AttributeValue attributeValueSS_v1 =
+            new com.amazonaws.services.dynamodbv2.model.AttributeValue().withSS(valueSS);
+    public static final com.amazonaws.services.dynamodbv2.model.AttributeValue attributeValueB_v1 =
+            new com.amazonaws.services.dynamodbv2.model.AttributeValue().withB(valueB);
+    public static final com.amazonaws.services.dynamodbv2.model.AttributeValue attributeValueBS_v1 =
+            new com.amazonaws.services.dynamodbv2.model.AttributeValue().withBS(valueBS);
+    public static final com.amazonaws.services.dynamodbv2.model.AttributeValue attributeValueBOOL_v1 =
+            new com.amazonaws.services.dynamodbv2.model.AttributeValue().withBOOL(valueBOOL);
+    public static final com.amazonaws.services.dynamodbv2.model.AttributeValue attributeValueNUL_v1 =
+            new com.amazonaws.services.dynamodbv2.model.AttributeValue().withNULL(valueNUL);
+    public static final com.amazonaws.services.dynamodbv2.model.AttributeValue attributeValueM_v1 =
+            new com.amazonaws.services.dynamodbv2.model.AttributeValue().withM(new HashMap<String, com.amazonaws.services.dynamodbv2.model.AttributeValue>() {{
+                put(keyM1, attributeValueN_v1);
+                put(keyM2, attributeValueS_v1);
+            }});
+    public static final com.amazonaws.services.dynamodbv2.model.AttributeValue attributeValueL_v1 =
+            new com.amazonaws.services.dynamodbv2.model.AttributeValue().withL(Arrays.asList(
+                    attributeValueN_v1,
+                    attributeValueNS_v1,
+                    attributeValueS_v1,
+                    attributeValueSS_v1,
+                    attributeValueB_v1,
+                    attributeValueBS_v1,
+                    attributeValueBOOL_v1,
+                    attributeValueNUL_v1,
+                    attributeValueM_v1,
+                    new com.amazonaws.services.dynamodbv2.model.AttributeValue().withL(Arrays.asList(
+                            attributeValueN_v1,
+                            attributeValueNS_v1,
+                            attributeValueS_v1,
+                            attributeValueSS_v1,
+                            attributeValueB_v1,
+                            attributeValueBS_v1,
+                            attributeValueBOOL_v1,
+                            attributeValueNUL_v1,
+                            attributeValueM_v1
+                    ))
+            ));
+    //endregion
+
+    @Test
+    public void testToAttributeValueV1_N() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue convertedAttributeValueN =
+                DynamodbAttributeValueTransformer.toAttributeValueV1(attributeValueN_event);
+        Assertions.assertEquals(attributeValueN_v1, convertedAttributeValueN);
+    }
+
+    @Test
+    public void testToAttributeValueV1_NS() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue convertedAttributeValueNS =
+                DynamodbAttributeValueTransformer.toAttributeValueV1(attributeValueNS_event);
+        Assertions.assertEquals(attributeValueNS_v1, convertedAttributeValueNS);
+    }
+
+    @Test
+    public void testToAttributeValueV1_S() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue convertedAttributeValueS =
+                DynamodbAttributeValueTransformer.toAttributeValueV1(attributeValueS_event);
+        Assertions.assertEquals(attributeValueS_v1, convertedAttributeValueS);
+    }
+
+    @Test
+    public void testToAttributeValueV1_SS() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue convertedAttributeValueSS =
+                DynamodbAttributeValueTransformer.toAttributeValueV1(attributeValueSS_event);
+        Assertions.assertEquals(attributeValueSS_v1, convertedAttributeValueSS);
+    }
+
+    @Test
+    public void testToAttributeValueV1_B() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue convertedAttributeValueB =
+                DynamodbAttributeValueTransformer.toAttributeValueV1(attributeValueB_event);
+        Assertions.assertEquals(attributeValueB_v1, convertedAttributeValueB);
+    }
+
+    @Test
+    public void testToAttributeValueV1_BS() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue convertedAttributeValueBS =
+                DynamodbAttributeValueTransformer.toAttributeValueV1(attributeValueBS_event);
+        Assertions.assertEquals(attributeValueBS_v1, convertedAttributeValueBS);
+    }
+
+    @Test
+    public void testToAttributeValueV1_BOOL() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue convertedAttributeValueBOOL =
+                DynamodbAttributeValueTransformer.toAttributeValueV1(attributeValueBOOL_event);
+        Assertions.assertEquals(attributeValueBOOL_v1, convertedAttributeValueBOOL);
+    }
+
+    @Test
+    public void testToAttributeValueV1_NUL() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue convertedAttributeValueNUL =
+                DynamodbAttributeValueTransformer.toAttributeValueV1(attributeValueNUL_event);
+        Assertions.assertEquals(attributeValueNUL_v1, convertedAttributeValueNUL);
+    }
+
+    @Test
+    public void testToAttributeValueV1_M() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue convertedAttributeValueM =
+                DynamodbAttributeValueTransformer.toAttributeValueV1(attributeValueM_event);
+        Assertions.assertEquals(attributeValueM_v1, convertedAttributeValueM);
+    }
+
+    @Test
+    public void testToAttributeValueV1_L() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue convertedAttributeValueL =
+                DynamodbAttributeValueTransformer.toAttributeValueV1(attributeValueL_event);
+        Assertions.assertEquals(attributeValueL_v1, convertedAttributeValueL);
+    }
+
+    @Test
+    public void testToAttributeValueV1_IllegalArgumentWhenNull() {
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue())
+        );
+    }
+
+    @Test
+    public void testToAttributeValueV1_IllegalArgumentWhenNull_N() {
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withN(null))
+        );
+    }
+
+    @Test
+    public void testToAttributeValueV1_IllegalArgumentWhenNull_S() {
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withS(null))
+        );
+    }
+
+    @Test
+    public void testToAttributeValueV1_IllegalArgumentWhenNull_B() {
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withB(null))
+        );
+    }
+
+    @Test
+    public void testToAttributeValueV1_IllegalArgumentWhenNull_BOOL() {
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withBOOL(null))
+        );
+    }
+
+    @Test
+    public void testToAttributeValueV1_IllegalArgumentWhenNull_NUL() {
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withNULL(null))
+        );
+    }
+
+    @Test
+    public void testToAttributeValueV1_IllegalArgumentWhenNull_M() {
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withM(null))
+        );
+    }
+
+    @Test
+    public void testToAttributeValueV1_DoesNotThrowWhenEmpty_NS() {
+        Assertions.assertDoesNotThrow(() ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withNS())
+        );
+        Assertions.assertDoesNotThrow(() ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withNS(Collections.emptyList()))
+        );
+    }
+
+    @Test
+    public void testToAttributeValueV1_DoesNotThrowWhenEmpty_SS() {
+        Assertions.assertDoesNotThrow(() ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withSS())
+        );
+        Assertions.assertDoesNotThrow(() ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withSS(Collections.emptyList()))
+        );
+    }
+
+    @Test
+    public void testToAttributeValueV1_DoesNotThrowWhenEmpty_BS() {
+        Assertions.assertDoesNotThrow(() ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withBS())
+        );
+        Assertions.assertDoesNotThrow(() ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withBS(Collections.emptyList()))
+        );
+    }
+
+    @Test
+    public void testToAttributeValueV1_DoesNotThrowWhenEmpty_L() {
+        Assertions.assertDoesNotThrow(() ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withL())
+        );
+        Assertions.assertDoesNotThrow(() ->
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withL(Collections.emptyList()))
+        );
+    }
+
+    @Test
+    public void testToAttributeValueV1_EmptyV1ObjectWhenEmpty_NS() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue expectedAttributeValue_v1 =
+                new com.amazonaws.services.dynamodbv2.model.AttributeValue();
+        Assertions.assertEquals(expectedAttributeValue_v1,
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withNS()));
+        Assertions.assertEquals(expectedAttributeValue_v1,
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withNS(Collections.emptyList())));
+    }
+
+    @Test
+    public void testToAttributeValueV1_EmptyV1ObjectWhenEmpty_SS() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue expectedAttributeValue_v1 =
+                new com.amazonaws.services.dynamodbv2.model.AttributeValue();
+        Assertions.assertEquals(expectedAttributeValue_v1,
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withSS()));
+        Assertions.assertEquals(expectedAttributeValue_v1,
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withSS(Collections.emptyList())));
+    }
+
+    @Test
+    public void testToAttributeValueV1_EmptyV1ObjectWhenEmpty_BS() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue expectedAttributeValue_v1 =
+                new com.amazonaws.services.dynamodbv2.model.AttributeValue();
+        Assertions.assertEquals(expectedAttributeValue_v1,
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withBS()));
+        Assertions.assertEquals(expectedAttributeValue_v1,
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withBS(Collections.emptyList())));
+    }
+
+    @Test
+    public void testToAttributeValueV1_EmptyV1ObjectWhenEmpty_L() {
+        com.amazonaws.services.dynamodbv2.model.AttributeValue expectedAttributeValue_v1 =
+                new com.amazonaws.services.dynamodbv2.model.AttributeValue();
+        Assertions.assertEquals(expectedAttributeValue_v1,
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withL()));
+        Assertions.assertEquals(expectedAttributeValue_v1,
+                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withL(Collections.emptyList())));
+    }
+
+}

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbIdentityTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbIdentityTransformerTest.java
@@ -1,0 +1,30 @@
+package com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.model.Identity;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DynamodbIdentityTransformerTest {
+
+    private static final String principalId = "1234567890";
+    private static final String identityType = "type";
+
+    //region Identity_event
+    public static final com.amazonaws.services.lambda.runtime.events.models.dynamodb.Identity identity_event = new com.amazonaws.services.lambda.runtime.events.models.dynamodb.Identity()
+            .withPrincipalId(principalId)
+            .withType(identityType);
+    //endregion
+
+    //region Identity_v1
+    public static final Identity identity_v1 = new Identity()
+            .withPrincipalId(principalId)
+            .withType(identityType);
+    //endregion
+
+    @Test
+    public void testToIdentityV1() {
+        Identity convertedIdentity = DynamodbIdentityTransformer.toIdentityV1(identity_event);
+        Assertions.assertEquals(identity_v1, convertedIdentity);
+    }
+
+}

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbRecordTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbRecordTransformerTest.java
@@ -1,0 +1,52 @@
+package com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.model.OperationType;
+import com.amazonaws.services.dynamodbv2.model.Record;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbIdentityTransformerTest.identity_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbIdentityTransformerTest.identity_v1;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbStreamRecordTransformerTest.streamRecord_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbStreamRecordTransformerTest.streamRecord_v1;
+
+public class DynamodbRecordTransformerTest {
+
+    private static final String eventId = "2";
+    private static final String eventName = OperationType.MODIFY.toString();
+    private static final String eventVersion = "1.0";
+    private static final String eventSource = "aws:dynamodb";
+    private static final String awsRegion = "us-west-2";
+
+    //region Record_event
+    public static final DynamodbEvent.DynamodbStreamRecord record_event = (DynamodbEvent.DynamodbStreamRecord)
+            new DynamodbEvent.DynamodbStreamRecord()
+                    .withEventID(eventId)
+                    .withEventName(eventName)
+                    .withEventVersion(eventVersion)
+                    .withEventSource(eventSource)
+                    .withAwsRegion(awsRegion)
+                    .withDynamodb(streamRecord_event)
+                    .withUserIdentity(identity_event);
+    //endregion
+
+    //region Record_v1
+    public static final Record record_v1 =
+            new Record()
+                    .withEventID(eventId)
+                    .withEventName(eventName)
+                    .withEventVersion(eventVersion)
+                    .withEventSource(eventSource)
+                    .withAwsRegion(awsRegion)
+                    .withDynamodb(streamRecord_v1)
+                    .withUserIdentity(identity_v1);
+    //endregion
+
+    @Test
+    public void testToRecordV1() {
+        Record convertedRecord = DynamodbRecordTransformer.toRecordV1(record_event);
+        Assertions.assertEquals(record_v1, convertedRecord);
+    }
+
+}

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbStreamRecordTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbStreamRecordTransformerTest.java
@@ -1,0 +1,130 @@
+package com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.model.StreamRecord;
+import com.amazonaws.services.dynamodbv2.model.StreamViewType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueBOOL_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueBOOL_v1;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueBS_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueBS_v1;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueB_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueB_v1;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueL_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueL_v1;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueM_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueM_v1;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueNS_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueNS_v1;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueNUL_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueNUL_v1;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueN_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueN_v1;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueSS_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueSS_v1;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueS_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueS_v1;
+
+class DynamodbStreamRecordTransformerTest {
+
+    private static final String keyNK = "Id";
+    private static final String keyNSK = "KeyNS";
+
+    private static final String keySK = "SKey";
+    private static final String keySSK = "KeySS";
+
+    private static final String keyBK = "BKey";
+    private static final String keyBSK = "KeyBS";
+
+    private static final String keyBOOLK = "IsBool";
+    private static final String keyNULK = "nil";
+
+    private static final String keyMK = "MapKey";
+
+    private static final String keyLK = "LongNum";
+
+    private static final String oldImageSK = "Message";
+    private static final String newImageSK = "Message";
+    private static final String streamViewType = StreamViewType.NEW_AND_OLD_IMAGES.toString();
+    private static final String sequenceNumber = "222";
+    private static final Long sizeBytes = 59L;
+    private static final Date approximateCreationDateTime = new Date();
+
+    //region StreamRecord_event
+    public static final com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord streamRecord_event = new com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord()
+            .withKeys(new HashMap<String, com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue>() {
+                {
+                    put(keyNK, attributeValueN_event);
+                    put(keyNSK, attributeValueNS_event);
+                    put(keySK, attributeValueS_event);
+                    put(keySSK, attributeValueSS_event);
+                    put(keyBK, attributeValueB_event);
+                    put(keyBSK, attributeValueBS_event);
+                    put(keyBOOLK, attributeValueBOOL_event);
+                    put(keyNULK, attributeValueNUL_event);
+                    put(keyMK, attributeValueM_event);
+                    put(keyLK, attributeValueL_event);
+                }
+            })
+            .withOldImage(new HashMap<String, com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue>() {
+                {
+                    put(oldImageSK, attributeValueS_event);
+                    put(keyNK, attributeValueN_event);
+                }
+            })
+            .withNewImage(new HashMap<String, com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue>() {
+                {
+                    put(newImageSK, attributeValueS_event);
+                    put(keyNK, attributeValueN_event);
+                }
+            })
+            .withStreamViewType(com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamViewType.fromValue(streamViewType))
+            .withSequenceNumber(sequenceNumber)
+            .withSizeBytes(sizeBytes)
+            .withApproximateCreationDateTime(approximateCreationDateTime);
+    //endregion
+
+    //region StreamRecord_v1
+    public static final StreamRecord streamRecord_v1 = new StreamRecord()
+            .withApproximateCreationDateTime(approximateCreationDateTime)
+            .withKeys(new HashMap<String, com.amazonaws.services.dynamodbv2.model.AttributeValue>() {
+                {
+                    put(keyNK, attributeValueN_v1);
+                    put(keyNSK, attributeValueNS_v1);
+                    put(keySK, attributeValueS_v1);
+                    put(keySSK, attributeValueSS_v1);
+                    put(keyBK, attributeValueB_v1);
+                    put(keyBSK, attributeValueBS_v1);
+                    put(keyBOOLK, attributeValueBOOL_v1);
+                    put(keyNULK, attributeValueNUL_v1);
+                    put(keyMK, attributeValueM_v1);
+                    put(keyLK, attributeValueL_v1);
+                }
+            })
+            .withOldImage(new HashMap<String, com.amazonaws.services.dynamodbv2.model.AttributeValue>() {
+                {
+                    put(oldImageSK, attributeValueS_v1);
+                    put(keyNK, attributeValueN_v1);
+                }
+            })
+            .withNewImage(new HashMap<String, com.amazonaws.services.dynamodbv2.model.AttributeValue>() {
+                {
+                    put(newImageSK, attributeValueS_v1);
+                    put(keyNK, attributeValueN_v1);
+                }
+            })
+            .withSequenceNumber(sequenceNumber)
+            .withSizeBytes(sizeBytes)
+            .withStreamViewType(streamViewType);
+    //endregion
+
+    @Test
+    public void testToStreamRecordV1() {
+        StreamRecord convertedStreamRecord = DynamodbStreamRecordTransformer.toStreamRecordV1(streamRecord_event);
+        Assertions.assertEquals(streamRecord_v1, convertedStreamRecord);
+    }
+}

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/DynamodbEventTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/DynamodbEventTransformerTest.java
@@ -1,0 +1,43 @@
+package com.amazonaws.services.lambda.runtime.events.transformers.v2;
+
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.Record;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbRecordTransformerTest.record_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbRecordTransformerTest.record_v2;
+
+public class DynamodbEventTransformerTest {
+
+    private final DynamodbEvent dynamodbEvent;
+
+    {
+        record_event.setEventSourceARN("arn:aws:dynamodb:us-west-2:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899");
+        dynamodbEvent = new DynamodbEvent();
+        dynamodbEvent.setRecords(Collections.singletonList(record_event));
+    }
+
+    private final List<Record> expectedRecordsV2 = Collections.singletonList(record_v2);
+
+    @Test
+    public void testDynamodbEventToRecordsV2() {
+        List<Record> convertedRecords = DynamodbEventTransformer.toRecordsV2(dynamodbEvent);
+        Assertions.assertEquals(expectedRecordsV2, convertedRecords);
+    }
+
+    @Test
+    public void testDynamodbEventToRecordsV2_FiltersNullRecords() {
+        DynamodbEvent event = dynamodbEvent.clone();
+        event.setRecords(Arrays.asList(record_event, null));
+        Assertions.assertEquals(2, event.getRecords().size());
+
+        List<Record> convertedRecords = DynamodbEventTransformer.toRecordsV2(event);
+        Assertions.assertEquals(expectedRecordsV2, convertedRecords);
+        Assertions.assertEquals(1, convertedRecords.size());
+    }
+}

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbAttributeValueTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbAttributeValueTransformerTest.java
@@ -1,4 +1,4 @@
-package com.amazonaws.services.lambda.runtime.events.transformers.dynamodb;
+package com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb;
 
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
 import org.junit.jupiter.api.Assertions;

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbIdentityTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbIdentityTransformerTest.java
@@ -1,4 +1,4 @@
-package com.amazonaws.services.lambda.runtime.events.transformers.dynamodb;
+package com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbRecordTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbRecordTransformerTest.java
@@ -1,4 +1,4 @@
-package com.amazonaws.services.lambda.runtime.events.transformers.dynamodb;
+package com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb;
 
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
 import org.junit.jupiter.api.Assertions;
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.OperationType;
 import software.amazon.awssdk.services.dynamodb.model.Record;
 
-import static com.amazonaws.services.lambda.runtime.events.transformers.dynamodb.DynamodbIdentityTransformerTest.identity_event;
-import static com.amazonaws.services.lambda.runtime.events.transformers.dynamodb.DynamodbIdentityTransformerTest.identity_v2;
-import static com.amazonaws.services.lambda.runtime.events.transformers.dynamodb.DynamodbStreamRecordTransformerTest.streamRecord_event;
-import static com.amazonaws.services.lambda.runtime.events.transformers.dynamodb.DynamodbStreamRecordTransformerTest.streamRecord_v2;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbIdentityTransformerTest.identity_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbIdentityTransformerTest.identity_v2;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbStreamRecordTransformerTest.streamRecord_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbStreamRecordTransformerTest.streamRecord_v2;
 
 public class DynamodbRecordTransformerTest {
 
@@ -21,14 +21,14 @@ public class DynamodbRecordTransformerTest {
 
     //region Record_event
     public static final DynamodbEvent.DynamodbStreamRecord record_event = (DynamodbEvent.DynamodbStreamRecord)
-                new DynamodbEvent.DynamodbStreamRecord()
-                        .withEventID(eventId)
-                        .withEventName(eventName)
-                        .withEventVersion(eventVersion)
-                        .withEventSource(eventSource)
-                        .withAwsRegion(awsRegion)
-                        .withDynamodb(streamRecord_event)
-                        .withUserIdentity(identity_event);
+            new DynamodbEvent.DynamodbStreamRecord()
+                    .withEventID(eventId)
+                    .withEventName(eventName)
+                    .withEventVersion(eventVersion)
+                    .withEventSource(eventSource)
+                    .withAwsRegion(awsRegion)
+                    .withDynamodb(streamRecord_event)
+                    .withUserIdentity(identity_event);
     //endregion
 
     //region Record_v2

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbStreamRecordTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbStreamRecordTransformerTest.java
@@ -1,4 +1,4 @@
-package com.amazonaws.services.lambda.runtime.events.transformers.dynamodb;
+package com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb;
 
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamViewType;
@@ -9,7 +9,26 @@ import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.util.Date;
 
-import static com.amazonaws.services.lambda.runtime.events.transformers.dynamodb.DynamodbAttributeValueTransformerTest.*;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueBOOL_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueBOOL_v2;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueBS_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueBS_v2;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueB_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueB_v2;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueL_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueL_v2;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueM_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueM_v2;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueNS_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueNS_v2;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueNUL_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueNUL_v2;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueN_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueN_v2;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueSS_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueSS_v2;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueS_event;
+import static com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbAttributeValueTransformerTest.attributeValueS_v2;
 
 class DynamodbStreamRecordTransformerTest {
 
@@ -39,7 +58,7 @@ class DynamodbStreamRecordTransformerTest {
     //region StreamRecord_event
     public static final com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord streamRecord_event =
             new com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord()
-                    .withKeys(ImmutableMap.<String, AttributeValue> builder()
+                    .withKeys(ImmutableMap.<String, AttributeValue>builder()
                             .put(keyNK, attributeValueN_event)
                             .put(keyNSK, attributeValueNS_event)
                             .put(keySK, attributeValueS_event)
@@ -69,7 +88,7 @@ class DynamodbStreamRecordTransformerTest {
     //region StreamRecord_v2
     public static final StreamRecord streamRecord_v2 = StreamRecord.builder()
             .approximateCreationDateTime(approximateCreationDateTime.toInstant())
-            .keys(ImmutableMap.<String, software.amazon.awssdk.services.dynamodb.model.AttributeValue> builder()
+            .keys(ImmutableMap.<String, software.amazon.awssdk.services.dynamodb.model.AttributeValue>builder()
                     .put(keyNK, attributeValueN_v2)
                     .put(keyNSK, attributeValueNS_v2)
                     .put(keySK, attributeValueS_v2)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-java-libs/issues/182

*Description of changes:*
- Added SDK v1 transformers (under `transformers.v1` package)
- Moved v2 transformers to `transformers.v2` package
- Bumped transformer lib to `3.0.0`

As the scope of these two SDK dependencies is `provided`, users have full control over which to include and use without having to include the other version. I've also opted to separate into different packages to keep a cleaner separation between v1 and v2 models and test cases.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
