### PR TITLE
Separate GitHub actions workflows

### DIFF
--- a/.github/workflows/aws-lambda-java-core.yml
+++ b/.github/workflows/aws-lambda-java-core.yml
@@ -1,12 +1,17 @@
-# This workflow will build all Java packages in this project with Maven (Java 8)
+# This workflow will be triggered if there will be changes to aws-lambda-java-core
+# package and it builds the package and the packages that depend on it.
 
-name: Java CI with Maven
+name: Java CI aws-lambda-java-core
 
 on:
   push:
     branches: [ master ]
+    paths:
+    - 'aws-lambda-java-core/**'
   pull_request:
     branches: [ '*' ]
+    paths:
+    - 'aws-lambda-java-core/**'
 
 jobs:
   build:
@@ -20,15 +25,11 @@ jobs:
       with:
         java-version: 1.8
     
-    # Install base modules
+    # Install base module
     - name: Build core with Maven
       run: mvn -B install --file aws-lambda-java-core/pom.xml
-    - name: Build events with Maven
-      run: mvn -B install --file aws-lambda-java-events/pom.xml
 
-    # Package modules that depend on base modules
-    - name: Build events-sdk-transformer with Maven
-      run: mvn -B package --file aws-lambda-java-events-sdk-transformer/pom.xml
+    # Package modules that depend on base module
     - name: Build log4j2 with Maven
       run: mvn -B package --file aws-lambda-java-log4j2/pom.xml
 

--- a/.github/workflows/aws-lambda-java-events-sdk-transformer.yml
+++ b/.github/workflows/aws-lambda-java-events-sdk-transformer.yml
@@ -1,0 +1,31 @@
+# This workflow will be triggered if there will be changes to 
+# aws-lambda-java-events-sdk-transformer package and it builds the package.
+
+name: Java CI aws-lambda-java-events-sdk-transformer
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+    - 'aws-lambda-java-events-sdk-transformer/**'
+  pull_request:
+    branches: [ '*' ]
+    paths:
+    - 'aws-lambda-java-events-sdk-transformer/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    
+    # Install base module
+    - name: Build events-sdk-transformer with Maven
+      run: mvn -B install --file aws-lambda-java-events-sdk-transformer/pom.xml
+    

--- a/.github/workflows/aws-lambda-java-events-sdk-transformer.yml
+++ b/.github/workflows/aws-lambda-java-events-sdk-transformer.yml
@@ -24,8 +24,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    
+
     # Install base module
+    - name: Build events with Maven
+      run: mvn -B install --file aws-lambda-java-events/pom.xml
+    # Package target module
     - name: Build events-sdk-transformer with Maven
-      run: mvn -B install --file aws-lambda-java-events-sdk-transformer/pom.xml
+      run: mvn -B package --file aws-lambda-java-events-sdk-transformer/pom.xml
     

--- a/.github/workflows/aws-lambda-java-events.yml
+++ b/.github/workflows/aws-lambda-java-events.yml
@@ -1,0 +1,37 @@
+# This workflow will be triggered if there will be changes to aws-lambda-java-events
+# package and it builds the package and the packages that depend on it.
+
+name: Java CI aws-lambda-java-events
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+    - 'aws-lambda-java-events/**'
+  pull_request:
+    branches: [ '*' ]
+    paths:
+    - 'aws-lambda-java-events/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    
+    # Install base module
+    - name: Build events with Maven
+      run: mvn -B install --file aws-lambda-java-events/pom.xml
+
+    # Package modules that depend on base module
+    - name: Build serialization with Maven
+      run: mvn -B package --file aws-lambda-java-serialization/pom.xml
+    - name: Build events-sdk-transformer with Maven
+      run: mvn -B package --file aws-lambda-java-events-sdk-transformer/pom.xml
+    

--- a/.github/workflows/aws-lambda-java-log4j2.yml
+++ b/.github/workflows/aws-lambda-java-log4j2.yml
@@ -1,0 +1,31 @@
+# This workflow will be triggered if there will be changes to 
+# aws-lambda-java-log4j2 package and it builds the package.
+
+name: Java CI aws-lambda-java-log4j2
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+    - 'aws-lambda-java-log4j2/**'
+  pull_request:
+    branches: [ '*' ]
+    paths:
+    - 'aws-lambda-java-log4j2/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    
+    # Install base module
+    - name: Build log4j2 with Maven
+      run: mvn -B install --file aws-lambda-java-log4j2/pom.xml
+    

--- a/.github/workflows/aws-lambda-java-log4j2.yml
+++ b/.github/workflows/aws-lambda-java-log4j2.yml
@@ -26,6 +26,9 @@ jobs:
         java-version: 1.8
     
     # Install base module
+    - name: Build core with Maven
+      run: mvn -B install --file aws-lambda-java-core/pom.xml
+    # Package target module
     - name: Build log4j2 with Maven
-      run: mvn -B install --file aws-lambda-java-log4j2/pom.xml
+      run: mvn -B package --file aws-lambda-java-log4j2/pom.xml
     

--- a/.github/workflows/aws-lambda-java-runtime-interface-client.yml
+++ b/.github/workflows/aws-lambda-java-runtime-interface-client.yml
@@ -1,0 +1,32 @@
+# This workflow will be triggered if there will be changes to 
+# aws-lambda-java-runtime-interface-client package and it builds the package.
+
+name: Java CI aws-lambda-java-runtime-interface-client
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+    - 'aws-lambda-java-runtime-interface-client/**'
+  pull_request:
+    branches: [ '*' ]
+    paths:
+    - 'aws-lambda-java-runtime-interface-client/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    
+    # Test Runtime Interface Client
+    - name: Run 'pr' target
+      working-directory: ./aws-lambda-java-runtime-interface-client
+      run: make pr
+    

--- a/.github/workflows/aws-lambda-java-runtime-interface-client.yml
+++ b/.github/workflows/aws-lambda-java-runtime-interface-client.yml
@@ -25,6 +25,11 @@ jobs:
       with:
         java-version: 1.8
     
+    # Install base modules
+    - name: Build core with Maven
+      run: mvn -B install --file aws-lambda-java-core/pom.xml
+    - name: Build serialization with Maven
+      run: mvn -B install --file aws-lambda-java-serialization/pom.xml
     # Test Runtime Interface Client
     - name: Run 'pr' target
       working-directory: ./aws-lambda-java-runtime-interface-client

--- a/.github/workflows/aws-lambda-java-serialization.yml
+++ b/.github/workflows/aws-lambda-java-serialization.yml
@@ -26,6 +26,9 @@ jobs:
         java-version: 1.8
     
     # Install base module
+    - name: Build events with Maven
+      run: mvn -B install --file aws-lambda-java-events/pom.xml
+    # Install target module
     - name: Build serialization with Maven
       run: mvn -B install --file aws-lambda-java-serialization/pom.xml
 

--- a/.github/workflows/aws-lambda-java-serialization.yml
+++ b/.github/workflows/aws-lambda-java-serialization.yml
@@ -1,0 +1,36 @@
+# This workflow will be triggered if there will be changes to aws-lambda-java-serialization 
+# package and it builds the package and the packages that depend on it.
+
+name: Java CI aws-lambda-java-serialization
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+    - 'aws-lambda-java-serialization/**'
+  pull_request:
+    branches: [ '*' ]
+    paths:
+    - 'aws-lambda-java-serialization/**'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    
+    # Install base module
+    - name: Build serialization with Maven
+      run: mvn -B install --file aws-lambda-java-serialization/pom.xml
+
+    # Test Runtime Interface Client
+    - name: Run 'pr' target
+      working-directory: ./aws-lambda-java-runtime-interface-client
+      run: make pr
+    


### PR DESCRIPTION
*Description of changes:*
- GitHub actions workflow currently builds all packages on push and pull request no matter of the package changed
- Separated the GitHub actions workflows to run based on the package changed. It builds the package changed and the packages that depend on that package. There could be some duplication builds if multiple packages are changed in a single pull request, but for most cases it should not be a problem since before including the RIC, building all the other packages took around 1 minute.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
