### PR TITLE
Increase scope of toAttributeValueMapV1 and V2, bump transformer to 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
@@ -60,7 +60,7 @@ ___
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
 'com.amazonaws:aws-lambda-java-events:3.6.0'
-'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.0'
+'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.1'
 'com.amazonaws:aws-lambda-java-log4j2:1.2.0'
 'com.amazonaws:aws-lambda-java-runtime-interface-client:1.0.0'
 ```
@@ -70,7 +70,7 @@ ___
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
 [com.amazonaws/aws-lambda-java-events "3.6.0"]
-[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.0"]
+[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.1"]
 [com.amazonaws/aws-lambda-java-log4j2 "1.2.0"]
 [com.amazonaws/aws-lambda-java-runtime-interface-client "1.0.0"]
 ```
@@ -80,7 +80,7 @@ ___
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
 "com.amazonaws" % "aws-lambda-java-events" % "3.6.0"
-"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.0"
+"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.1"
 "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0"
 "com.amazonaws" % "aws-lambda-java-runtime-interface-client" % "1.0.0"
 ```

--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -16,7 +16,7 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### Upcoming
+`3.0.1`:
+- Change visibility scope of `Map<String, AttributeValue> toAttributeValueMapVx(Map<String, AttributeValue>)` to `public`
+
 ### December 09, 2020
 `3.0.0`:
 - Added AWS SDK V1 transformers for `DynamodbEvent` in `aws-lambda-java-events` versions `3.0.0` and up

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events SDK Transformer Library</name>

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformer.java
@@ -59,7 +59,7 @@ public class DynamodbAttributeValueTransformer {
         }
     }
 
-    static Map<String, AttributeValue> toAttributeValueMapV1(
+    public static Map<String, AttributeValue> toAttributeValueMapV1(
             final Map<String, com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue> attributeValueMap
     ) {
         return attributeValueMap

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbAttributeValueTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbAttributeValueTransformer.java
@@ -74,7 +74,7 @@ public class DynamodbAttributeValueTransformer {
         }
     }
 
-    static Map<String, AttributeValue> toAttributeValueMapV2(
+    public static Map<String, AttributeValue> toAttributeValueMapV2(
             final Map<String, com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue> attributeValueMap
     ) {
         return attributeValueMap


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-java-libs/issues/198

*Description of changes:*
- Changed scope of `Map<String, AttributeValue> toAttributeValueMapV1(Map<String, AttributeValue>)` to public
- Changed scope of `Map<String, AttributeValue> toAttributeValueMapV2(Map<String, AttributeValue>)` to public
- Bumped sdk transformer to version `3.0.1`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
