### PR TITLE
New events structures for StreamAnalytics and CustomCheckpointing

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/DynamodbTimeWindowEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/DynamodbTimeWindowEvent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.amazonaws.services.lambda.runtime.events;
+
+import com.amazonaws.services.lambda.runtime.events.models.TimeWindow;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class DynamodbTimeWindowEvent extends DynamodbEvent implements Serializable, Cloneable {
+
+    private static final long serialVersionUID = -5449871161108629510L;
+
+    private TimeWindow window;
+    private Map<String, String> state;
+    private String shardId;
+    private String eventSourceArn;
+    private Boolean isFinalInvokeForWindow;
+    private Boolean isWindowTerminatedEarly;
+
+    @Builder(setterPrefix = "with")
+    public DynamodbTimeWindowEvent(
+            final List<DynamodbStreamRecord> records,
+            final TimeWindow window,
+            final Map<String, String> state,
+            final String shardId,
+            final String eventSourceArn,
+            final Boolean isFinalInvokeForWindow,
+            final Boolean isWindowTerminatedEarly) {
+        this.setRecords(records);
+        this.window = window;
+        this.state = state;
+        this.shardId = shardId;
+        this.eventSourceArn = eventSourceArn;
+        this.isFinalInvokeForWindow = isFinalInvokeForWindow;
+        this.isWindowTerminatedEarly = isWindowTerminatedEarly;
+    }
+}

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisTimeWindowEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KinesisTimeWindowEvent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.amazonaws.services.lambda.runtime.events;
+
+import com.amazonaws.services.lambda.runtime.events.models.TimeWindow;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class KinesisTimeWindowEvent extends KinesisEvent implements Serializable, Cloneable {
+
+    private static final long serialVersionUID = 8926430039233062266L;
+
+    private TimeWindow window;
+    private Map<String, String> state;
+    private String shardId;
+    private String eventSourceArn;
+    private Boolean isFinalInvokeForWindow;
+    private Boolean isWindowTerminatedEarly;
+
+    @Builder(setterPrefix = "with")
+    public KinesisTimeWindowEvent(
+            final List<KinesisEventRecord> records,
+            final TimeWindow window,
+            final Map<String, String> state,
+            final String shardId,
+            final String eventSourceArn,
+            final Boolean isFinalInvokeForWindow,
+            final Boolean isWindowTerminatedEarly) {
+        this.setRecords(records);
+        this.window = window;
+        this.state = state;
+        this.shardId = shardId;
+        this.eventSourceArn = eventSourceArn;
+        this.isFinalInvokeForWindow = isFinalInvokeForWindow;
+        this.isWindowTerminatedEarly = isWindowTerminatedEarly;
+    }
+}

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/StreamsEventResponse.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/StreamsEventResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.amazonaws.services.lambda.runtime.events;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(setterPrefix = "with")
+public class StreamsEventResponse implements Serializable {
+    private static final long serialVersionUID = 3232053116472095907L;
+
+    private List<BatchItemFailure> batchItemFailures;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder(setterPrefix = "with")
+    public static class BatchItemFailure implements Serializable {
+        private static final long serialVersionUID = 1473983466096085881L;
+
+        String itemIdentifier;
+    }
+}

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/TimeWindowEventResponse.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/TimeWindowEventResponse.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.amazonaws.services.lambda.runtime.events;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(setterPrefix = "with")
+public class TimeWindowEventResponse implements Serializable {
+    private static final long serialVersionUID = 2259096191791166028L;
+
+    private Map<String, String> state;
+    private List<BatchItemFailure> batchItemFailures;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder(setterPrefix = "with")
+    public static class BatchItemFailure implements Serializable {
+        private static final long serialVersionUID = 5224634072234167773L;
+
+        String itemIdentifier;
+    }
+}

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/models/TimeWindow.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/models/TimeWindow.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.amazonaws.services.lambda.runtime.events.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder(setterPrefix = "with")
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeWindow {
+    private String start;
+    private String end;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added new events `DynamodbTimeWindowEvent` and `KinesisTimeWindowEvent` for supporting stream analytics.
Added a couple of event response classes. `StreamsEventResponse` will be used to report batch item failures for Kinesis and Dynamodb events. `TimeWindowEventResponse` will be used for returning the stream analytics state as well as reporting batch item failures for `KinesisTimeWindowEvent` and `DynamodbTimeWindowEvent`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
