### PR TITLE
Feat: Support for IAM Policy Responses for API Gateway REST APIs.

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/IamPolicyResponseV1.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/IamPolicyResponseV1.java
@@ -12,9 +12,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * The IAM Policy Response required for API Gateway HTTP APIs
+ * The IAM Policy Response required for API Gateway REST APIs
  *
- * https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html
+ * https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html
  *
  */
 
@@ -22,7 +22,7 @@ import java.util.Map;
 @Builder(setterPrefix = "with")
 @NoArgsConstructor
 @AllArgsConstructor
-public class IamPolicyResponse implements Serializable, Cloneable {
+public class IamPolicyResponseV1 implements Serializable, Cloneable {
 
     public static final String EXECUTE_API_INVOKE = "execute-api:Invoke";
     public static final String VERSION_2012_10_17 = "2012-10-17";
@@ -32,6 +32,7 @@ public class IamPolicyResponse implements Serializable, Cloneable {
     private String principalId;
     private PolicyDocument policyDocument;
     private Map<String, Object> context;
+    private String usageIdentifierKey;
 
     public Map<String, Object> getPolicyDocument() {
         Map<String, Object> serializablePolicy = new HashMap<>();

--- a/aws-lambda-java-events/src/test/java/com/amazonaws/services/lambda/runtime/events/IamPolicyResponseV1Test.java
+++ b/aws-lambda-java-events/src/test/java/com/amazonaws/services/lambda/runtime/events/IamPolicyResponseV1Test.java
@@ -1,0 +1,94 @@
+package com.amazonaws.services.lambda.runtime.events;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.amazonaws.services.lambda.runtime.events.IamPolicyResponseV1.ALLOW;
+import static com.amazonaws.services.lambda.runtime.events.IamPolicyResponseV1.EXECUTE_API_INVOKE;
+import static com.amazonaws.services.lambda.runtime.events.IamPolicyResponseV1.VERSION_2012_10_17;
+import static com.amazonaws.services.lambda.runtime.events.IamPolicyResponseV1.allowStatement;
+import static com.amazonaws.services.lambda.runtime.events.IamPolicyResponseV1.denyStatement;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+public class IamPolicyResponseV1Test {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    public void testAllowStatement() throws JsonProcessingException {
+        IamPolicyResponseV1 iamPolicyResponse = IamPolicyResponseV1.builder()
+                .withPrincipalId("me")
+                .withPolicyDocument(IamPolicyResponseV1.PolicyDocument.builder()
+                        .withVersion(VERSION_2012_10_17)
+                        .withStatement(singletonList(allowStatement("arn:aws:execute-api:eu-west-1:123456789012:1234abc/$deafult/*/*")))
+                        .build())
+                .withUsageIdentifierKey("123ABC")
+                .build();
+
+        String json = OBJECT_MAPPER.writeValueAsString(iamPolicyResponse);
+
+        assertThatJson(json).isEqualTo(readResource("iamPolicyV1Responses/allow.json"));
+    }
+
+    @Test
+    public void testDenyStatement() throws JsonProcessingException {
+        IamPolicyResponseV1 iamPolicyResponse = IamPolicyResponseV1.builder()
+                .withPrincipalId("me")
+                .withPolicyDocument(IamPolicyResponseV1.PolicyDocument.builder()
+                        .withVersion(VERSION_2012_10_17)
+                        .withStatement(singletonList(denyStatement("arn:aws:execute-api:eu-west-1:123456789012:1234abc/$deafult/*/*")))
+                        .build())
+                .withUsageIdentifierKey("123ABC")
+                .build();
+
+        String json = OBJECT_MAPPER.writeValueAsString(iamPolicyResponse);
+
+        assertThatJson(json).isEqualTo(readResource("iamPolicyV1Responses/deny.json"));
+    }
+
+    @Test
+    public void testStatementWithCondition() throws JsonProcessingException {
+        Map<String, Map<String, Object>> conditions = new HashMap<>();
+        conditions.put("DateGreaterThan", singletonMap("aws:TokenIssueTime", "2020-01-01T00:00:01Z"));
+
+        IamPolicyResponseV1 iamPolicyResponse = IamPolicyResponseV1.builder()
+                .withPrincipalId("me")
+                .withPolicyDocument(IamPolicyResponseV1.PolicyDocument.builder()
+                        .withVersion(VERSION_2012_10_17)
+                        .withStatement(singletonList(IamPolicyResponseV1.Statement.builder()
+                                .withAction(EXECUTE_API_INVOKE)
+                                .withEffect(ALLOW)
+                                .withResource(singletonList("arn:aws:execute-api:eu-west-1:123456789012:1234abc/$deafult/*/*"))
+                                .withCondition(conditions)
+                                .build()))
+                        .build())
+                .withUsageIdentifierKey("123ABC")
+                .build();
+
+        String json = OBJECT_MAPPER.writeValueAsString(iamPolicyResponse);
+
+        assertThatJson(json).isEqualTo(readResource("iamPolicyV1Responses/allow-with-condition.json"));
+    }
+
+    private String readResource(String name) {
+        Path filePath = Paths.get("src", "test", "resources", name);
+        byte[] bytes = new byte[0];
+        try {
+            bytes = Files.readAllBytes(filePath);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+}

--- a/aws-lambda-java-events/src/test/resources/iamPolicyV1Responses/allow-with-condition.json
+++ b/aws-lambda-java-events/src/test/resources/iamPolicyV1Responses/allow-with-condition.json
@@ -1,0 +1,14 @@
+{
+  "principalId": "me",
+  "policyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Action": "execute-api:Invoke",
+      "Resource": ["arn:aws:execute-api:eu-west-1:123456789012:1234abc/$deafult/*/*"],
+      "Effect": "Allow",
+      "Condition": {"DateGreaterThan": {"aws:TokenIssueTime": "2020-01-01T00:00:01Z"}}
+    }]
+  },
+  "context":null,
+  "usageIdentifierKey": "123ABC"
+}

--- a/aws-lambda-java-events/src/test/resources/iamPolicyV1Responses/allow.json
+++ b/aws-lambda-java-events/src/test/resources/iamPolicyV1Responses/allow.json
@@ -1,0 +1,14 @@
+{
+  "principalId": "me",
+  "policyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Action": "execute-api:Invoke",
+      "Resource": ["arn:aws:execute-api:eu-west-1:123456789012:1234abc/$deafult/*/*"],
+      "Effect": "Allow",
+      "Condition": null
+    }]
+  },
+  "context":null,
+  "usageIdentifierKey": "123ABC"
+}

--- a/aws-lambda-java-events/src/test/resources/iamPolicyV1Responses/deny.json
+++ b/aws-lambda-java-events/src/test/resources/iamPolicyV1Responses/deny.json
@@ -1,0 +1,14 @@
+{
+  "principalId": "me",
+  "policyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Action": "execute-api:Invoke",
+      "Resource": ["arn:aws:execute-api:eu-west-1:123456789012:1234abc/$deafult/*/*"],
+      "Effect": "Deny",
+      "Condition": null
+    }]
+  },
+  "context":null,
+  "usageIdentifierKey": "123ABC"
+}


### PR DESCRIPTION
These are different to HTTP APIs responses as they include a required field for 'usageIdentifierKey'.

*Issue #, if available:*
https://github.com/aws/aws-lambda-java-libs/issues/184

*Description of changes:*
Feat: Support for IAM Policy Responses for API Gateway REST APIs.
These are different to HTTP APIs responses as they include a required field for 'usageIdentifierKey'.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
