### PR TITLE
use environment variable _HANDLER if no args

### DIFF
--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/AWSLambda.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/AWSLambda.java
@@ -185,7 +185,7 @@ public class AWSLambda {
 
     public static void main(String[] args) {
         // TODO validate arguments, show usage
-        startRuntime(args[0]);
+        startRuntime(args.length > 0 ? args[0] : getEnvOrExit("_HANDLER"));
     }
 
     private static void startRuntime(String handler) {


### PR DESCRIPTION
Right now `AWSLambda` main method expects the handler to be supplied as an argument. This PR uses the environment variable `_HANDLER` if no argument is provided. 

see: https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime

> `_HANDLER` – The handler location configured on the function.