### PR TITLE
Stage events 3.9.0, sdk-transformer 3.0.4, RIC 1.1.0, and tests 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events</artifactId>
-  <version>3.8.0</version>
+  <version>3.9.0</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>3.0.3</version>
+  <version>3.0.4</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
@@ -52,12 +52,12 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-tests</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -66,33 +66,33 @@ ___
 
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
-'com.amazonaws:aws-lambda-java-events:3.8.0'
-'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.3'
+'com.amazonaws:aws-lambda-java-events:3.9.0'
+'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.4'
 'com.amazonaws:aws-lambda-java-log4j2:1.2.0'
-'com.amazonaws:aws-lambda-java-runtime-interface-client:1.0.0'
-'com.amazonaws:aws-lambda-java-tests:1.0.1'
+'com.amazonaws:aws-lambda-java-runtime-interface-client:1.1.0'
+'com.amazonaws:aws-lambda-java-tests:1.0.2'
 ```
 
 [Leiningen](http://leiningen.org) and [Boot](http://boot-clj.com)
 
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
-[com.amazonaws/aws-lambda-java-events "3.8.0"]
-[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.3"]
+[com.amazonaws/aws-lambda-java-events "3.9.0"]
+[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.4"]
 [com.amazonaws/aws-lambda-java-log4j2 "1.2.0"]
-[com.amazonaws/aws-lambda-java-runtime-interface-client "1.0.0"]
-[com.amazonaws/aws-lambda-java-tests "1.0.1"]
+[com.amazonaws/aws-lambda-java-runtime-interface-client "1.1.0"]
+[com.amazonaws/aws-lambda-java-tests "1.0.2"]
 ```
 
 [sbt](http://www.scala-sbt.org)
 
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
-"com.amazonaws" % "aws-lambda-java-events" % "3.8.0"
-"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.3"
+"com.amazonaws" % "aws-lambda-java-events" % "3.9.0"
+"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.4"
 "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0"
-"com.amazonaws" % "aws-lambda-java-runtime-interface-client" % "1.0.0"
-"com.amazonaws" % "aws-lambda-java-tests" % "1.0.1"
+"com.amazonaws" % "aws-lambda-java-runtime-interface-client" % "1.1.0"
+"com.amazonaws" % "aws-lambda-java-tests" % "1.0.2"
 ```
 
 # Using aws-lambda-java-core

--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -16,12 +16,12 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.4</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.8.0</version>
+        <version>3.9.0</version>
     </dependency>
 </dependencies>
 ```

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### June 2, 2021
+`3.0.4`:
+- Bumped `aws-lambda-java-events` to version `3.9.0`
+
 ### March 24, 2021
 `3.0.3`:
 - Bumped `aws-lambda-java-events` to version `3.8.0`

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>3.0.3</version>
+  <version>3.0.4</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events SDK Transformer Library</name>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>3.8.0</version>
+      <version>3.9.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/aws-lambda-java-events/README.md
+++ b/aws-lambda-java-events/README.md
@@ -17,6 +17,17 @@
 * `CloudWatchLogsEvent`
 * `CodeCommitEvent`
 * `CognitoEvent`
+* `CognitoUserPoolCreateAuthChallengeEvent`
+* `CognitoUserPoolCustomMessageEvent`
+* `CognitoUserPoolDefineAuthChallengeEvent`
+* `CognitoUserPoolEvent`
+* `CognitoUserPoolMigrateUserEvent`
+* `CognitoUserPoolPostAuthenticationEvent`
+* `CognitoUserPoolPostConfirmationEvent`
+* `CognitoUserPoolPreAuthenticationEvent`
+* `CognitoUserPoolPreSignUpEvent`
+* `CognitoUserPoolPreTokenGenerationEvent`
+* `CognitoUserPoolVerifyAuthChallengeResponseEvent`
 * `ConfigEvent`
 * `ConnectEvent`
 * `DynamodbEvent`
@@ -58,7 +69,7 @@
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.8.0</version>
+        <version>3.9.0</version>
     </dependency>
     ...
 </dependencies>
@@ -68,19 +79,19 @@
 
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
-'com.amazonaws:aws-lambda-java-events:3.8.0'
+'com.amazonaws:aws-lambda-java-events:3.9.0'
 ```
 
 [Leiningen](http://leiningen.org) and [Boot](http://boot-clj.com)
 
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
-[com.amazonaws/aws-lambda-java-events "3.8.0"]
+[com.amazonaws/aws-lambda-java-events "3.9.0"]
 ```
 
 [sbt](http://www.scala-sbt.org)
 
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
-"com.amazonaws" % "aws-lambda-java-events" % "3.8.0"
+"com.amazonaws" % "aws-lambda-java-events" % "3.9.0"
 ```

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,3 +1,24 @@
+### June 2, 2021
+`3.9.0`:
+- Added support for Cognito User Pool events ([#175](https://github.com/aws/aws-lambda-java-libs/pull/175))
+  - `CognitoUserPoolCreateAuthChallengeEvent`
+  - `CognitoUserPoolCustomMessageEvent`
+  - `CognitoUserPoolDefineAuthChallengeEvent`
+  - `CognitoUserPoolEvent`
+  - `CognitoUserPoolMigrateUserEvent`
+  - `CognitoUserPoolPostAuthenticationEvent`
+  - `CognitoUserPoolPostConfirmationEvent`
+  - `CognitoUserPoolPreAuthenticationEvent`
+  - `CognitoUserPoolPreSignUpEvent`
+  - `CognitoUserPoolPreTokenGenerationEvent`
+  - `CognitoUserPoolVerifyAuthChallengeResponseEvent`
+- Added support for IAM Policy Responses for API Gateway REST APIs ([#213](https://github.com/aws/aws-lambda-java-libs/pull/213))
+ - `IamPolicyResponseV1`
+- Added default IntelliJ equals, hashCode and toString methods to `APIGatewayV2WebSocketEvent` ([#248](https://github.com/aws/aws-lambda-java-libs/pull/248))
+- Fixed toString method in `KinesisEvent` ([#245](https://github.com/aws/aws-lambda-java-libs/pull/245))
+- Changed `body` field to lowercase in `APIGatewayV2HTTPEvent` ([#236](https://github.com/aws/aws-lambda-java-libs/pull/236))
+- Added `principalOrgId` field to `APIGatewayProxyRequestEvent` ([#247](https://github.com/aws/aws-lambda-java-libs/pull/247))
+
 ### March 24, 2021
 `3.8.0`:
 - Added support for S3 Object Lambda event ([#229](https://github.com/aws/aws-lambda-java-libs/pull/229))

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events</artifactId>
-  <version>3.8.0</version>
+  <version>3.9.0</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events Library</name>

--- a/aws-lambda-java-runtime-interface-client/README.md
+++ b/aws-lambda-java-runtime-interface-client/README.md
@@ -70,7 +70,7 @@ pom.xml
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/aws-lambda-java-runtime-interface-client/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-runtime-interface-client/RELEASE.CHANGELOG.md
@@ -1,3 +1,8 @@
+### June 02, 2020
+`1.1.0`:
+- Added reserved environment variables constants ([#238](https://github.com/aws/aws-lambda-java-libs/pull/238))
+- Updated libcurl dependency to `7.77.0` ([#249](https://github.com/aws/aws-lambda-java-libs/pull/249))
+
 ### December 01, 2020
 `1.0.0`:
 - Initial release of AWS Lambda Java Runtime Interface Client

--- a/aws-lambda-java-runtime-interface-client/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Runtime Interface Client</name>

--- a/aws-lambda-java-runtime-interface-client/test/integration/test-handler/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/test-handler/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
     </dependencies>
 

--- a/aws-lambda-java-serialization/pom.xml
+++ b/aws-lambda-java-serialization/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.8.0</version>
+            <version>3.9.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/aws-lambda-java-tests/README.md
+++ b/aws-lambda-java-tests/README.md
@@ -39,7 +39,7 @@ To install this utility, add the following dependency to your project. Note that
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-tests</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/aws-lambda-java-tests/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-tests/RELEASE.CHANGELOG.md
@@ -1,4 +1,8 @@
 ### March 24, 2021
+`1.0.2`:
+- Bumped `aws-lambda-java-events` to version `3.9.0`
+
+### March 24, 2021
 `1.0.1`:
 - Added sorting to the event/response files to guarantee order ([#218](https://github.com/aws/aws-lambda-java-libs/pull/218))
 - Added `bootstrapServers` to Kafka Event tests ([#216](https://github.com/aws/aws-lambda-java-libs/pull/216))

--- a/aws-lambda-java-tests/pom.xml
+++ b/aws-lambda-java-tests/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-tests</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Tests</name>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.8.0</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
*Description of changes:*
Staging releases:
- `aws-lambda-java-events` version `3.9.0`
- `aws-lambda-java-events-sdk-transformer` version `3.0.4`
- `aws-lambda-java-runtime-interface-client` version `1.1.0`
- `aws-lambda-java-tests` version `1.0.2`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
