### PR TITLE
Add null checks to handle null new image and old image in StreamRecord

### DIFF
--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformer.java
@@ -63,6 +63,10 @@ public class DynamodbAttributeValueTransformer {
     public static Map<String, AttributeValue> toAttributeValueMapV1(
             final Map<String, com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue> attributeValueMap
     ) {
+        if (attributeValueMap == null) {
+            return null;
+        }
+
         return attributeValueMap
                 .entrySet()
                 .stream()

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformerTest.java
@@ -313,4 +313,9 @@ class DynamodbAttributeValueTransformerTest {
                 DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withL(Collections.emptyList())));
     }
 
+    @Test
+    public void testToAttributeValueMapV1_NullV1AttributeValueMapWhenNullEventAttributeValueMap() {
+        Assertions.assertNull(DynamodbAttributeValueTransformer.toAttributeValueMapV1(null));
+    }
+
 }


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Old image and new image don't always exist in the DynamoDB stream record. When either of them don't exist, a NullPointerException would be thrown without null checks. The same null checks exist in [com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb.DynamodbStreamRecordTransformer](https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbStreamRecordTransformer.java#L16-L25), but not com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbStreamRecordTransformer

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
