### PR TITLE
Missing version field

### DIFF
--- a/.github/workflows/aws-lambda-java-serialization.yml
+++ b/.github/workflows/aws-lambda-java-serialization.yml
@@ -30,4 +30,4 @@ jobs:
       run: mvn -B install --file aws-lambda-java-events/pom.xml
     # Package target module
     - name: Package serialization with Maven
-      run: mvn -B install --file aws-lambda-java-serialization/pom.xml
+      run: mvn -B package --file aws-lambda-java-serialization/pom.xml

--- a/.github/workflows/aws-lambda-java-serialization.yml
+++ b/.github/workflows/aws-lambda-java-serialization.yml
@@ -30,4 +30,4 @@ jobs:
       run: mvn -B install --file aws-lambda-java-events/pom.xml
     # Package target module
     - name: Package serialization with Maven
-      run: mvn -B package --file aws-lambda-java-serialization/pom.xml
+      run: mvn -B install --file aws-lambda-java-serialization/pom.xml

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/APIGatewayProxyRequestEvent.java
@@ -11,6 +11,8 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
 
     private static final long serialVersionUID = 4189228800688527467L;
 
+    private String version;
+
     private String resource;
 
     private String path;
@@ -872,6 +874,29 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
     public APIGatewayProxyRequestEvent() {}
 
     /**
+     * @return The payload format version
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * @param version The payload format version
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * @param version The payload format version
+     * @return
+     */
+    public APIGatewayProxyRequestEvent withVersion(String version) {
+        this.setVersion(version);
+        return this;
+    }
+
+    /**
      * @return The resource path defined in API Gateway
      */
     public String getResource() {
@@ -1174,6 +1199,8 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("{");
+        if (getVersion() != null)
+            sb.append("version: ").append(getVersion()).append(",");
         if (getResource() != null)
             sb.append("resource: ").append(getResource()).append(",");
         if (getPath() != null)
@@ -1212,6 +1239,10 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
         if (obj instanceof APIGatewayProxyRequestEvent == false)
             return false;
         APIGatewayProxyRequestEvent other = (APIGatewayProxyRequestEvent) obj;
+        if (other.getVersion() == null ^ this.getVersion() == null)
+            return false;
+        if (other.getVersion() != null && other.getVersion().equals(this.getVersion()) == false)
+            return false;
         if (other.getResource() == null ^ this.getResource() == null)
             return false;
         if (other.getResource() != null && other.getResource().equals(this.getResource()) == false)
@@ -1268,6 +1299,7 @@ public class APIGatewayProxyRequestEvent implements Serializable, Cloneable {
         final int prime = 31;
         int hashCode = 1;
 
+        hashCode = prime * hashCode + ((getVersion() == null) ? 0 : getVersion().hashCode());
         hashCode = prime * hashCode + ((getResource() == null) ? 0 : getResource().hashCode());
         hashCode = prime * hashCode + ((getPath() == null) ? 0 : getPath().hashCode());
         hashCode = prime * hashCode + ((getHttpMethod() == null) ? 0 : getHttpMethod().hashCode());

--- a/aws-lambda-java-serialization/src/test/resources/event_models/api_gateway_proxy_request_event.json
+++ b/aws-lambda-java-serialization/src/test/resources/event_models/api_gateway_proxy_request_event.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0",
   "path": "/test/hello",
   "headers": {
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-java-libs/issues/207

*Description of changes:*
This is a little complex due to the various different modes of operation around REST and HTTP APIs, with the old (v1) and new (v2) message formats.

- REST APIs should use `APIGatewayProxyRequestEvent` a version won't be set. This doesn't cause a problem, but `getVersion()` does return a null.
- HTTP APIs using v1 and the `APIGatewayProxyRequestEvent` will have "1.0" set for the version.
- HTTP APIs using v2 and the `APIGatewayProxyRequestEvent` will have "2.0" set for the version.
- HTTP APIs using v2 should use the `APIGatewayV2HTTPEvent` to take advantage of the changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
