### PR TITLE
Fix NPE when user identity is null for SDK v1

### DIFF
--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbRecordTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbRecordTransformer.java
@@ -16,7 +16,9 @@ public class DynamodbRecordTransformer {
                 .withEventSource(record.getEventSource())
                 .withEventVersion(record.getEventVersion())
                 .withUserIdentity(
-                        DynamodbIdentityTransformer.toIdentityV1(record.getUserIdentity())
+                        record.getUserIdentity() != null
+                                ? DynamodbIdentityTransformer.toIdentityV1(record.getUserIdentity())
+                                : null
                 );
     }
 }

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbStreamRecordTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbStreamRecordTransformer.java
@@ -13,10 +13,14 @@ public class DynamodbStreamRecordTransformer {
                         DynamodbAttributeValueTransformer.toAttributeValueMapV1(streamRecord.getKeys())
                 )
                 .withNewImage(
-                        DynamodbAttributeValueTransformer.toAttributeValueMapV1(streamRecord.getNewImage())
+                        streamRecord.getNewImage() != null
+                                ? DynamodbAttributeValueTransformer.toAttributeValueMapV1(streamRecord.getNewImage())
+                                : null
                 )
                 .withOldImage(
-                        DynamodbAttributeValueTransformer.toAttributeValueMapV1(streamRecord.getOldImage())
+                        streamRecord.getOldImage() != null
+                                ? DynamodbAttributeValueTransformer.toAttributeValueMapV1(streamRecord.getOldImage())
+                                : null
                 )
                 .withSequenceNumber(streamRecord.getSequenceNumber())
                 .withSizeBytes(streamRecord.getSizeBytes())

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbRecordTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbRecordTransformerTest.java
@@ -3,6 +3,7 @@ package com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb;
 import com.amazonaws.services.dynamodbv2.model.OperationType;
 import com.amazonaws.services.dynamodbv2.model.Record;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.transformers.v1.DynamodbEventTransformer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -47,6 +48,16 @@ public class DynamodbRecordTransformerTest {
     public void testToRecordV1() {
         Record convertedRecord = DynamodbRecordTransformer.toRecordV1(record_event);
         Assertions.assertEquals(record_v1, convertedRecord);
+    }
+
+    @Test
+    public void testToRecordV1WhenUserIdentityIsNull() {
+        DynamodbEvent.DynamodbStreamRecord record = record_event.clone();
+        record.setUserIdentity(null);
+
+        Assertions.assertDoesNotThrow(() -> {
+            com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbRecordTransformer.toRecordV1(record);
+        });
     }
 
 }

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbStreamRecordTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbStreamRecordTransformerTest.java
@@ -127,4 +127,24 @@ class DynamodbStreamRecordTransformerTest {
         StreamRecord convertedStreamRecord = DynamodbStreamRecordTransformer.toStreamRecordV1(streamRecord_event);
         Assertions.assertEquals(streamRecord_v1, convertedStreamRecord);
     }
+
+    @Test
+    public void testToStreamRecordV1WhenOldImageIsNull() {
+        com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord streamRecord = streamRecord_event.clone();
+        streamRecord.setOldImage(null);
+
+        Assertions.assertDoesNotThrow(() -> {
+            com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbStreamRecordTransformer.toStreamRecordV1(streamRecord);
+        });
+    }
+
+    @Test
+    public void testToStreamRecordV1WhenNewImageIsNull() {
+        com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord streamRecord = streamRecord_event.clone();
+        streamRecord.setNewImage(null);
+
+        Assertions.assertDoesNotThrow(() -> {
+            com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb.DynamodbStreamRecordTransformer.toStreamRecordV1(streamRecord);
+        });
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
#168 same issue as this, which was fixed for SDK v2 in #169 

*Description of changes:*
Fixes a potential NPE when `userIdentity` is null and added a null check to the OldImage and NewImage for dynamo stream records.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
