### PR TITLE
Stage events 3.10.0, sdk-transformer 3.0.5, and tests 1.1.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events</artifactId>
-  <version>3.9.0</version>
+  <version>3.10.0</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>3.0.4</version>
+  <version>3.0.5</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
@@ -57,7 +57,7 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-tests</artifactId>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -66,33 +66,33 @@ ___
 
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
-'com.amazonaws:aws-lambda-java-events:3.9.0'
-'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.4'
+'com.amazonaws:aws-lambda-java-events:3.10.0'
+'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.5'
 'com.amazonaws:aws-lambda-java-log4j2:1.2.0'
 'com.amazonaws:aws-lambda-java-runtime-interface-client:1.1.0'
-'com.amazonaws:aws-lambda-java-tests:1.0.2'
+'com.amazonaws:aws-lambda-java-tests:1.1.0'
 ```
 
 [Leiningen](http://leiningen.org) and [Boot](http://boot-clj.com)
 
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
-[com.amazonaws/aws-lambda-java-events "3.9.0"]
-[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.4"]
+[com.amazonaws/aws-lambda-java-events "3.10.0"]
+[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.5"]
 [com.amazonaws/aws-lambda-java-log4j2 "1.2.0"]
 [com.amazonaws/aws-lambda-java-runtime-interface-client "1.1.0"]
-[com.amazonaws/aws-lambda-java-tests "1.0.2"]
+[com.amazonaws/aws-lambda-java-tests "1.1.0"]
 ```
 
 [sbt](http://www.scala-sbt.org)
 
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
-"com.amazonaws" % "aws-lambda-java-events" % "3.9.0"
-"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.4"
+"com.amazonaws" % "aws-lambda-java-events" % "3.10.0"
+"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.5"
 "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0"
 "com.amazonaws" % "aws-lambda-java-runtime-interface-client" % "1.1.0"
-"com.amazonaws" % "aws-lambda-java-tests" % "1.0.2"
+"com.amazonaws" % "aws-lambda-java-tests" % "1.1.0"
 ```
 
 # Using aws-lambda-java-core

--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -16,12 +16,12 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-        <version>3.0.4</version>
+        <version>3.0.5</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.9.0</version>
+        <version>3.10.0</version>
     </dependency>
 </dependencies>
 ```

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### August 26, 2021
+`3.0.5`:
+- Bumped `aws-lambda-java-events` to version `3.10.0`
+
 ### June 2, 2021
 `3.0.4`:
 - Bumped `aws-lambda-java-events` to version `3.9.0`

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>3.0.4</version>
+  <version>3.0.5</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events SDK Transformer Library</name>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>3.9.0</version>
+      <version>3.10.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/aws-lambda-java-events/README.md
+++ b/aws-lambda-java-events/README.md
@@ -12,6 +12,8 @@
 * `APIGatewayV2WebSocketResponse`
 * `ApplicationLoadBalancerRequestEvent`
 * `ApplicationLoadBalancerResponseEvent`
+* `AppSyncLambdaAuthorizerEvent`
+* `AppSyncLambdaAuthorizerResponse`
 * `CloudFormationCustomResourceEvent`
 * `CloudFrontEvent`
 * `CloudWatchLogsEvent`
@@ -42,6 +44,7 @@
 * `KinesisFirehoseEvent`
 * `LambdaDestinationEvent`
 * `LexEvent`
+* `RabbitMQEvent`
 * `S3BatchEvent`
 * `S3BatchResponse`
 * `S3Event`
@@ -69,7 +72,7 @@
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.9.0</version>
+        <version>3.10.0</version>
     </dependency>
     ...
 </dependencies>
@@ -79,19 +82,19 @@
 
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
-'com.amazonaws:aws-lambda-java-events:3.9.0'
+'com.amazonaws:aws-lambda-java-events:3.10.0'
 ```
 
 [Leiningen](http://leiningen.org) and [Boot](http://boot-clj.com)
 
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
-[com.amazonaws/aws-lambda-java-events "3.9.0"]
+[com.amazonaws/aws-lambda-java-events "3.10.0"]
 ```
 
 [sbt](http://www.scala-sbt.org)
 
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
-"com.amazonaws" % "aws-lambda-java-events" % "3.9.0"
+"com.amazonaws" % "aws-lambda-java-events" % "3.10.0"
 ```

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,3 +1,13 @@
+### August 26, 2021
+`3.10.0`:
+- Added headers in `KafkaEventRecord` ([#260](https://github.com/aws/aws-lambda-java-libs/pull/260))
+- Added support for AppSync Lambda Authorizer ([#263](https://github.com/aws/aws-lambda-java-libs/pull/263))
+  - `AppSyncLambdaAuthorizerEvent`
+  - `AppSyncLambdaAuthorizerResponse`
+- Added support for RabbitMQ Event ([#256](https://github.com/aws/aws-lambda-java-libs/pull/256))
+  - `RabbitMQEvent`
+- Added missing `version` field to `APIGatewayProxyRequestEvent` ([#258](https://github.com/aws/aws-lambda-java-libs/pull/258))
+
 ### June 2, 2021
 `3.9.0`:
 - Added support for Cognito User Pool events ([#175](https://github.com/aws/aws-lambda-java-libs/pull/175))

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events</artifactId>
-  <version>3.9.0</version>
+  <version>3.10.0</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events Library</name>

--- a/aws-lambda-java-serialization/pom.xml
+++ b/aws-lambda-java-serialization/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.9.0</version>
+            <version>3.10.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/aws-lambda-java-tests/README.md
+++ b/aws-lambda-java-tests/README.md
@@ -39,7 +39,7 @@ To install this utility, add the following dependency to your project. Note that
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-tests</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/aws-lambda-java-tests/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-tests/RELEASE.CHANGELOG.md
@@ -1,3 +1,9 @@
+### August 26, 2021
+`1.1.0`:
+- Added test for `RabbitMQEvent` ([#256](https://github.com/aws/aws-lambda-java-libs/pull/256))
+- Added test for `KafkaEventRecord` headers ([#260](https://github.com/aws/aws-lambda-java-libs/pull/260))
+- Bumped `aws-lambda-java-events` to version `3.10.0`
+
 ### March 24, 2021
 `1.0.2`:
 - Bumped `aws-lambda-java-events` to version `3.9.0`

--- a/aws-lambda-java-tests/pom.xml
+++ b/aws-lambda-java-tests/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-tests</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Tests</name>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.9.0</version>
+            <version>3.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
*Description of changes:*
Staging releases:
- `aws-lambda-java-events` version `3.10.0`
- `aws-lambda-java-events-sdk-transformer` version `3.0.5`
- `aws-lambda-java-tests` version `1.1.0`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
