### PR TITLE
Stage sdk-transformer 3.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>3.0.5</version>
+  <version>3.0.6</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
@@ -67,7 +67,7 @@ ___
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
 'com.amazonaws:aws-lambda-java-events:3.10.0'
-'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.5'
+'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.6'
 'com.amazonaws:aws-lambda-java-log4j2:1.2.0'
 'com.amazonaws:aws-lambda-java-runtime-interface-client:1.1.0'
 'com.amazonaws:aws-lambda-java-tests:1.1.0'
@@ -78,7 +78,7 @@ ___
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
 [com.amazonaws/aws-lambda-java-events "3.10.0"]
-[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.5"]
+[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.6"]
 [com.amazonaws/aws-lambda-java-log4j2 "1.2.0"]
 [com.amazonaws/aws-lambda-java-runtime-interface-client "1.1.0"]
 [com.amazonaws/aws-lambda-java-tests "1.1.0"]
@@ -89,7 +89,7 @@ ___
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
 "com.amazonaws" % "aws-lambda-java-events" % "3.10.0"
-"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.5"
+"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.6"
 "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0"
 "com.amazonaws" % "aws-lambda-java-runtime-interface-client" % "1.1.0"
 "com.amazonaws" % "aws-lambda-java-tests" % "1.1.0"

--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -16,7 +16,7 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-        <version>3.0.5</version>
+        <version>3.0.6</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### September 02, 2021
+`3.0.6`:
+- Fixed NPE when UserIdentity, OldImage, or NewImage is null ([#264](https://github.com/aws/aws-lambda-java-libs/pull/264))
+
 ### August 26, 2021
 `3.0.5`:
 - Bumped `aws-lambda-java-events` to version `3.10.0`

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>3.0.5</version>
+  <version>3.0.6</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events SDK Transformer Library</name>


### PR DESCRIPTION
*Description of changes:*

Stage `aws-lambda-java-events-sdk-transformer` version `3.0.6`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
