### PR TITLE
Allow the user-agent to be overridden

### DIFF
--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/NativeClient.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/NativeClient.java
@@ -38,9 +38,10 @@ class NativeClient {
                 System.exit(-1);
             }
             String userAgent = String.format(
-                    "aws-lambda-java/%s-%s" ,
+                    "%s/%s-%s",
+                    System.getProperty("RUNTIME_CLIENT", "aws-lambda-java"),
                     System.getProperty("java.vendor.version"),
-                    NativeClient.class.getPackage().getImplementationVersion());
+                    System.getProperty("RUNTIME_CLIENT_VERSION", NativeClient.class.getPackage().getImplementationVersion()));
             initializeClient(userAgent.getBytes());
     }
 

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/NativeClient.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/NativeClient.java
@@ -39,9 +39,9 @@ class NativeClient {
             }
             String userAgent = String.format(
                     "%s/%s-%s",
-                    System.getProperty("RUNTIME_CLIENT", "aws-lambda-java"),
+                    System.getProperty("AWS_LAMBDA_RUNTIME_CLIENT_NAME_OVERRIDE", "aws-lambda-java"),
                     System.getProperty("java.vendor.version"),
-                    System.getProperty("RUNTIME_CLIENT_VERSION", NativeClient.class.getPackage().getImplementationVersion()));
+                    System.getProperty("AWS_LAMBDA_RUNTIME_CLIENT_VERSION_OVERRIDE", NativeClient.class.getPackage().getImplementationVersion()));
             initializeClient(userAgent.getBytes());
     }
 


### PR DESCRIPTION
Allow the user-agent to be overridden by 3rd party developers of the runtime-interface-client.

*Issue #, if available:*
None

*Description of changes:*
When the aws-lambda-java-runtime-interface-client makes requests to the Lambda Runtime API it does them with a specific user-agent. This allows tracking and analysis of the clients and their versions. 

Now that the aws-lambda-java-runtime-interface-client is being used by 3rd party framework developers it would be advantageous to be able to differentiate them.

This change introduces two additional ways that the user-agent can be overridden from the default. The original implementation sends 3 strings in the following format '%s/%s-%s'.

```java
String userAgent = String.format(
        "aws-lambda-java/%s-%s" ,
        System.getProperty("java.vendor.version"),
        NativeClient.class.getPackage().getImplementationVersion());
```

The proposal allows for an override of the first string 'aws-lambda-java' if the env var 'RUNTIME_CLIENT' is present. If it is not then the default of 'aws-lambda-java' is used. 

An override of the third string which is the pom version id with the env var 'RUNTIME_CLIENT_VERSION' if it is present. If it is not then the original implementation is used.

This change will introduce no changes to the user-agent for typical usage. It will allow 3rd party framework developers to set environment variables in bootstrap scripts to override the user-agent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
