### PR TITLE
Stage events 3.11.0, sdk-transformer 3.0.7, and tests 1.1.1

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -25,6 +25,13 @@ jobs:
         with:
           java-version: 1.8
 
-      # Install base module
+      # Install events module
+      - name: Install events with Maven
+        run: mvn -B install --file aws-lambda-java-events/pom.xml
+      # Install tests module
+      - name: Install tests with Maven
+        run: mvn -B install --file aws-lambda-java-tests/pom.xml
+
+      # Install samples
       - name: Install Kinesis Firehose Sample with Maven
         run: mvn -B install --file samples/kinesis-firehose-event-handler/pom.xml

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events</artifactId>
-  <version>3.10.0</version>
+  <version>3.11.0</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>3.0.6</version>
+  <version>3.0.7</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
@@ -57,7 +57,7 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-tests</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -66,33 +66,33 @@ ___
 
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
-'com.amazonaws:aws-lambda-java-events:3.10.0'
-'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.6'
+'com.amazonaws:aws-lambda-java-events:3.11.0'
+'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.7'
 'com.amazonaws:aws-lambda-java-log4j2:1.2.0'
 'com.amazonaws:aws-lambda-java-runtime-interface-client:2.0.0'
-'com.amazonaws:aws-lambda-java-tests:1.1.0'
+'com.amazonaws:aws-lambda-java-tests:1.1.1'
 ```
 
 [Leiningen](http://leiningen.org) and [Boot](http://boot-clj.com)
 
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
-[com.amazonaws/aws-lambda-java-events "3.10.0"]
-[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.6"]
+[com.amazonaws/aws-lambda-java-events "3.11.0"]
+[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.7"]
 [com.amazonaws/aws-lambda-java-log4j2 "1.2.0"]
 [com.amazonaws/aws-lambda-java-runtime-interface-client "2.0.0"]
-[com.amazonaws/aws-lambda-java-tests "1.1.0"]
+[com.amazonaws/aws-lambda-java-tests "1.1.1"]
 ```
 
 [sbt](http://www.scala-sbt.org)
 
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
-"com.amazonaws" % "aws-lambda-java-events" % "3.10.0"
-"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.6"
+"com.amazonaws" % "aws-lambda-java-events" % "3.11.0"
+"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.7"
 "com.amazonaws" % "aws-lambda-java-log4j2" % "1.2.0"
 "com.amazonaws" % "aws-lambda-java-runtime-interface-client" % "2.0.0"
-"com.amazonaws" % "aws-lambda-java-tests" % "1.1.0"
+"com.amazonaws" % "aws-lambda-java-tests" % "1.1.1"
 ```
 
 # Using aws-lambda-java-core

--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -16,12 +16,12 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-        <version>3.0.6</version>
+        <version>3.0.7</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.10.0</version>
+        <version>3.11.0</version>
     </dependency>
 </dependencies>
 ```

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### November 24, 2021
+`3.0.7`:
+- Bumped `aws-lambda-java-events` to version `3.11.0`
+
 ### September 02, 2021
 `3.0.6`:
 - Fixed NPE when UserIdentity, OldImage, or NewImage is null ([#264](https://github.com/aws/aws-lambda-java-libs/pull/264))

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>3.0.6</version>
+  <version>3.0.7</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events SDK Transformer Library</name>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>3.10.0</version>
+      <version>3.11.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/aws-lambda-java-events/README.md
+++ b/aws-lambda-java-events/README.md
@@ -52,6 +52,7 @@
 * `SecretsManagerRotationEvent`
 * `SimpleIAMPolicyResponse`
 * `SNSEvent`
+* `SQSBatchResponse`
 * `SQSEvent`
 
 *As of version `3.0.0`, users are no longer required to pull in SDK dependencies in order to use this library.*
@@ -72,7 +73,7 @@
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.10.0</version>
+        <version>3.11.0</version>
     </dependency>
     ...
 </dependencies>
@@ -82,19 +83,19 @@
 
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
-'com.amazonaws:aws-lambda-java-events:3.10.0'
+'com.amazonaws:aws-lambda-java-events:3.11.0'
 ```
 
 [Leiningen](http://leiningen.org) and [Boot](http://boot-clj.com)
 
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
-[com.amazonaws/aws-lambda-java-events "3.10.0"]
+[com.amazonaws/aws-lambda-java-events "3.11.0"]
 ```
 
 [sbt](http://www.scala-sbt.org)
 
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
-"com.amazonaws" % "aws-lambda-java-events" % "3.10.0"
+"com.amazonaws" % "aws-lambda-java-events" % "3.11.0"
 ```

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,3 +1,8 @@
+### November 24, 2021
+`3.11.0`:
+- Added support for SQSaaES Partial Batch Feature ([#279](https://github.com/aws/aws-lambda-java-libs/pull/279))
+  - `SQSBatchResponse`
+
 ### August 26, 2021
 `3.10.0`:
 - Added headers in `KafkaEventRecord` ([#260](https://github.com/aws/aws-lambda-java-libs/pull/260))

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events</artifactId>
-  <version>3.10.0</version>
+  <version>3.11.0</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events Library</name>

--- a/aws-lambda-java-serialization/pom.xml
+++ b/aws-lambda-java-serialization/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.10.0</version>
+            <version>3.11.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/aws-lambda-java-tests/README.md
+++ b/aws-lambda-java-tests/README.md
@@ -39,7 +39,7 @@ To install this utility, add the following dependency to your project. Note that
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-tests</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/aws-lambda-java-tests/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-tests/RELEASE.CHANGELOG.md
@@ -1,4 +1,8 @@
 ### August 26, 2021
+`1.1.1`:
+- Bumped `aws-lambda-java-events` to version `3.11.0`
+
+### August 26, 2021
 `1.1.0`:
 - Added test for `RabbitMQEvent` ([#256](https://github.com/aws/aws-lambda-java-libs/pull/256))
 - Added test for `KafkaEventRecord` headers ([#260](https://github.com/aws/aws-lambda-java-libs/pull/260))

--- a/aws-lambda-java-tests/pom.xml
+++ b/aws-lambda-java-tests/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-tests</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Tests</name>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.10.0</version>
+            <version>3.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/samples/kinesis-firehose-event-handler/pom.xml
+++ b/samples/kinesis-firehose-event-handler/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.10.0</version>
+            <version>3.11.0</version>
         </dependency>
 
         <dependency>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-tests</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
*Description of changes:*
Staging releases:
- `aws-lambda-java-events` version `3.11.0`
- `aws-lambda-java-events-sdk-transformer` version `3.0.7`
- `aws-lambda-java-tests` version `1.1.1`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
