### PR TITLE
test: starts a serialization tck

### DIFF
--- a/aws-lambda-java-serialization/src/test/java/com/amazonaws/services/lambda/runtime/serialization/events/serializers/S3EventSerializerTest.java
+++ b/aws-lambda-java-serialization/src/test/java/com/amazonaws/services/lambda/runtime/serialization/events/serializers/S3EventSerializerTest.java
@@ -4,15 +4,12 @@ package com.amazonaws.services.lambda.runtime.serialization.events.serializers;
 
 import com.amazonaws.services.lambda.runtime.events.S3Event;
 import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
+import com.amazonaws.services.lambda.runtime.serialization.events.tck.EventUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -26,7 +23,7 @@ public class S3EventSerializerTest {
     public void testSerDeS3Event() throws IOException {
         S3EventSerializer<S3Event> s3EventSerializer = getS3EventSerializerWithClass(S3Event.class);
 
-        String expected = readEvent("s3_event.json");
+        String expected = EventUtils.readEvent("s3_event.json");
         String actual = deserializeSerializeJsonToString(s3EventSerializer, expected);
 
         assertJsonEqual(expected, actual);
@@ -36,7 +33,7 @@ public class S3EventSerializerTest {
     public void testSerDeS3EventNotification() throws IOException {
         S3EventSerializer<S3EventNotification> s3EventSerializer = getS3EventSerializerWithClass(S3EventNotification.class);
 
-        String expected = readEvent("s3_event.json");
+        String expected = EventUtils.readEvent("s3_event.json");
         String actual = deserializeSerializeJsonToString(s3EventSerializer, expected);
 
         assertJsonEqual(expected, actual);
@@ -48,15 +45,6 @@ public class S3EventSerializerTest {
                 .withClassLoader(SYSTEM_CLASS_LOADER);
     }
 
-    private String readEvent(String filename) throws IOException {
-        Path filePath = Paths.get("src", "test", "resources", "event_models", filename);
-        byte[] bytes = Files.readAllBytes(filePath);
-        return bytesToString(bytes);
-    }
-
-    private String bytesToString(byte[] bytes) {
-        return new String(bytes, StandardCharsets.UTF_8);
-    }
 
     private void assertJsonEqual(String expected, String actual) throws IOException {
         assertEquals(OBJECT_MAPPER.readTree(expected), OBJECT_MAPPER.readTree(actual));
@@ -67,7 +55,7 @@ public class S3EventSerializerTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         s3EventSerializer.toJson(event, baos);
-        return bytesToString(baos.toByteArray());
+        return EventUtils.bytesToString(baos.toByteArray());
     }
 
 }

--- a/aws-lambda-java-serialization/src/test/java/com/amazonaws/services/lambda/runtime/serialization/events/tck/EventUtils.java
+++ b/aws-lambda-java-serialization/src/test/java/com/amazonaws/services/lambda/runtime/serialization/events/tck/EventUtils.java
@@ -1,0 +1,20 @@
+/* Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+package com.amazonaws.services.lambda.runtime.serialization.events.tck;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public final class EventUtils {
+    public static String readEvent(String filename) throws IOException {
+        Path filePath = Paths.get("src", "test", "resources", "event_models", filename);
+        byte[] bytes = Files.readAllBytes(filePath);
+        return bytesToString(bytes);
+    }
+    public static String bytesToString(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+}

--- a/aws-lambda-java-serialization/src/test/java/com/amazonaws/services/lambda/runtime/serialization/events/tck/SQSEventTest.java
+++ b/aws-lambda-java-serialization/src/test/java/com/amazonaws/services/lambda/runtime/serialization/events/tck/SQSEventTest.java
@@ -1,0 +1,50 @@
+/* Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+package com.amazonaws.services.lambda.runtime.serialization.events.tck;
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.serialization.PojoSerializer;
+import com.amazonaws.services.lambda.runtime.serialization.events.mixins.SQSEventMixin;
+import com.amazonaws.services.lambda.runtime.serialization.factories.JacksonFactory;
+import org.junit.jupiter.api.Test;
+import java.io.IOException;
+import java.util.Collections;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class SQSEventTest {
+
+    @Test
+    void testDeserializationOfSqsRecieveMessageEvent() throws IOException {
+        //given:
+        JacksonFactory factory = JacksonFactory.getInstance().withMixin(SQSEvent.class, SQSEventMixin.class);
+        PojoSerializer<SQSEvent> serializer = factory.getSerializer(SQSEvent.class);
+
+        //when:
+        String json = EventUtils.readEvent("sqs-receive-message.json");
+        SQSEvent sqsEvent = serializer.fromJson(json);
+
+        //then:
+        assertNotNull(sqsEvent);
+        assertNotNull(sqsEvent.getRecords());
+        assertEquals(1, sqsEvent.getRecords().size());
+
+        //when:
+        SQSEvent.SQSMessage sqsMessage = sqsEvent.getRecords().get(0);
+
+        //then:
+        assertEquals("19dd0b57-b21e-4ac1-bd88-01bbb068cb78", sqsMessage.getMessageId());
+        assertEquals("MessageReceiptHandle", sqsMessage.getReceiptHandle());
+        assertEquals("Hello from SQS!", sqsMessage.getBody());
+        assertEquals(Collections.emptyMap(), sqsMessage.getMessageAttributes());
+        assertEquals("{{{md5_of_body}}}", sqsMessage.getMd5OfBody());
+        assertEquals("aws:sqs", sqsMessage.getEventSource());
+        //TODO this fails
+        // assertEquals("arn:aws:sqs:us-east-1:123456789012:MyQueue", sqsMessage.getEventSourceArn());
+        assertEquals("us-east-1", sqsMessage.getAwsRegion());
+        assertNotNull(sqsMessage.getAttributes());
+        assertEquals("1", sqsMessage.getAttributes().get("ApproximateReceiveCount"));
+        assertEquals("1523232000000", sqsMessage.getAttributes().get("SentTimestamp"));
+        assertEquals("123456789012", sqsMessage.getAttributes().get("SenderId"));
+        assertEquals("1523232000001", sqsMessage.getAttributes().get("ApproximateFirstReceiveTimestamp"));
+    }
+}

--- a/aws-lambda-java-serialization/src/test/resources/event_models/sqs-receive-message.json
+++ b/aws-lambda-java-serialization/src/test/resources/event_models/sqs-receive-message.json
@@ -1,0 +1,20 @@
+{
+  "Records": [
+    {
+      "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
+      "receiptHandle": "MessageReceiptHandle",
+      "body": "Hello from SQS!",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1523232000000",
+        "SenderId": "123456789012",
+        "ApproximateFirstReceiveTimestamp": "1523232000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "{{{md5_of_body}}}",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:us-east-1:123456789012:MyQueue",
+      "awsRegion": "us-east-1"
+    }
+  ]
+}


### PR DESCRIPTION
This starts a TCK for events serialization. Third-party libraries could copy this tck and replace the implementation of `PojoSerialization`

```java
        JacksonFactory factory = JacksonFactory.getInstance().withMixin(SQSEvent.class, SQSEventMixin.class);
        PojoSerializer<SQSEvent> serializer = factory.getSerializer(SQSEvent.class);
```
and provide their own implementations of `PojoSerializer` 

@msailes  what do you think?

