### PR TITLE
Update `log4j-core` and `log4j-api` dependencies to `2.16.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-log4j2</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
@@ -68,7 +68,7 @@ ___
 'com.amazonaws:aws-lambda-java-core:1.2.1'
 'com.amazonaws:aws-lambda-java-events:3.11.0'
 'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.7'
-'com.amazonaws:aws-lambda-java-log4j2:1.3.0'
+'com.amazonaws:aws-lambda-java-log4j2:1.3.1'
 'com.amazonaws:aws-lambda-java-runtime-interface-client:2.0.0'
 'com.amazonaws:aws-lambda-java-tests:1.1.1'
 ```
@@ -79,7 +79,7 @@ ___
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
 [com.amazonaws/aws-lambda-java-events "3.11.0"]
 [com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.7"]
-[com.amazonaws/aws-lambda-java-log4j2 "1.3.0"]
+[com.amazonaws/aws-lambda-java-log4j2 "1.3.1"]
 [com.amazonaws/aws-lambda-java-runtime-interface-client "2.0.0"]
 [com.amazonaws/aws-lambda-java-tests "1.1.1"]
 ```
@@ -90,7 +90,7 @@ ___
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
 "com.amazonaws" % "aws-lambda-java-events" % "3.11.0"
 "com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.7"
-"com.amazonaws" % "aws-lambda-java-log4j2" % "1.3.0"
+"com.amazonaws" % "aws-lambda-java-log4j2" % "1.3.1"
 "com.amazonaws" % "aws-lambda-java-runtime-interface-client" % "2.0.0"
 "com.amazonaws" % "aws-lambda-java-tests" % "1.1.1"
 ```

--- a/aws-lambda-java-log4j2/README.md
+++ b/aws-lambda-java-log4j2/README.md
@@ -15,12 +15,12 @@ Example for Maven pom.xml
   <dependency>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-core</artifactId>
-    <version>2.15.0</version>
+    <version>2.16.0</version>
   </dependency>
   <dependency>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-api</artifactId>
-    <version>2.15.0</version>
+    <version>2.16.0</version>
   </dependency>
   ....
 </dependencies>

--- a/aws-lambda-java-log4j2/README.md
+++ b/aws-lambda-java-log4j2/README.md
@@ -10,7 +10,7 @@ Example for Maven pom.xml
   <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-log4j2</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
   </dependency>
   <dependency>
     <groupId>org.apache.logging.log4j</groupId>
@@ -68,7 +68,7 @@ If you are using the [John Rengelman](https://github.com/johnrengelman/shadow) G
  
 dependencies{
   ...
-    implementation group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.3.0'
+    implementation group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.3.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: log4jVersion
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4jVersion
 }

--- a/aws-lambda-java-log4j2/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-log4j2/RELEASE.CHANGELOG.md
@@ -1,4 +1,8 @@
 ### December 10, 2021
+`1.3.1`:
+- Updated `log4j-core` and `log4j-api` dependencies to `2.16.0`
+
+### December 10, 2021
 `1.3.0`:
 - Updated `log4j-core` and `log4j-api` dependencies to `2.15.0`
 

--- a/aws-lambda-java-log4j2/pom.xml
+++ b/aws-lambda-java-log4j2/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-log4j2</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Log4j 2.x Libraries</name>
@@ -34,7 +34,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-java-libs/issues/289

*Description of changes:*
Mitigates against additional log4shell scenarios by upgrading log4j dependencies to 2.16.0

- Update `log4j-core` and `log4j-api` dependencies to 2.16.0
- Stage update to `aws-lambda-java-log4j2` version 1.3.1

[GitHub Advisory](https://github.com/advisories/GHSA-7rjr-3q55-vv33)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
