### PR TITLE
Update log4j-core and log4j-api dependencies to 2.17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-log4j2</artifactId>
-  <version>1.5.0</version>
+  <version>1.5.1</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
@@ -68,7 +68,7 @@ ___
 'com.amazonaws:aws-lambda-java-core:1.2.1'
 'com.amazonaws:aws-lambda-java-events:3.11.0'
 'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.7'
-'com.amazonaws:aws-lambda-java-log4j2:1.5.0'
+'com.amazonaws:aws-lambda-java-log4j2:1.5.1'
 'com.amazonaws:aws-lambda-java-runtime-interface-client:2.0.0'
 'com.amazonaws:aws-lambda-java-tests:1.1.1'
 ```
@@ -79,7 +79,7 @@ ___
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
 [com.amazonaws/aws-lambda-java-events "3.11.0"]
 [com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.7"]
-[com.amazonaws/aws-lambda-java-log4j2 "1.5.0"]
+[com.amazonaws/aws-lambda-java-log4j2 "1.5.1"]
 [com.amazonaws/aws-lambda-java-runtime-interface-client "2.0.0"]
 [com.amazonaws/aws-lambda-java-tests "1.1.1"]
 ```
@@ -90,7 +90,7 @@ ___
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
 "com.amazonaws" % "aws-lambda-java-events" % "3.11.0"
 "com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.7"
-"com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.0"
+"com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1"
 "com.amazonaws" % "aws-lambda-java-runtime-interface-client" % "2.0.0"
 "com.amazonaws" % "aws-lambda-java-tests" % "1.1.1"
 ```

--- a/aws-lambda-java-log4j2/README.md
+++ b/aws-lambda-java-log4j2/README.md
@@ -10,17 +10,17 @@ Example for Maven pom.xml
   <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-log4j2</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
   </dependency>
   <dependency>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-core</artifactId>
-    <version>2.17.0</version>
+    <version>2.17.1</version>
   </dependency>
   <dependency>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-api</artifactId>
-    <version>2.17.0</version>
+    <version>2.17.1</version>
   </dependency>
   ....
 </dependencies>
@@ -68,7 +68,7 @@ If you are using the [John Rengelman](https://github.com/johnrengelman/shadow) G
  
 dependencies{
   ...
-    implementation group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.5.0'
+    implementation group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.5.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: log4jVersion
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4jVersion
 }

--- a/aws-lambda-java-log4j2/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-log4j2/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### December 29, 2021
+`1.5.1`:
+- Updated `log4j-core` and `log4j-api` dependencies to `2.17.1`
+
 ### December 18, 2021
 `1.5.0`:
 - Updated `log4j-core` and `log4j-api` dependencies to `2.17.0`

--- a/aws-lambda-java-log4j2/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-log4j2/RELEASE.CHANGELOG.md
@@ -1,4 +1,4 @@
-### December 29, 2021
+### January 04, 2022
 `1.5.1`:
 - Updated `log4j-core` and `log4j-api` dependencies to `2.17.1`
 

--- a/aws-lambda-java-log4j2/pom.xml
+++ b/aws-lambda-java-log4j2/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-log4j2</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Log4j 2.x Libraries</name>
@@ -34,7 +34,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
*Description of changes:*

- Update log4j-core and log4j-api dependencies to 2.17.1
- Stage update to aws-lambda-java-log4j2 version 1.5.1
    
[CVE-2021-44832](https://logging.apache.org/log4j/2.x/security.html#:~:text=CVE-2021-44832)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
