### PR TITLE
DynamodbAttributeValueTransformer v1 and v2 return empty list instead of null for empty list attribute

### DIFF
--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformer.java
@@ -2,6 +2,7 @@ package com.amazonaws.services.lambda.runtime.events.transformers.v1.dynamodb;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -40,7 +41,7 @@ public class DynamodbAttributeValueTransformer {
         } else if (Objects.nonNull(value.getL())) {
             return new AttributeValue()
                     .withL(value.getL().isEmpty()
-                            ? null
+                            ? Collections.emptyList()
                             : value.getL().stream()
                                 .map(DynamodbAttributeValueTransformer::toAttributeValueV1)
                                 .collect(Collectors.toList()));

--- a/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbAttributeValueTransformer.java
+++ b/aws-lambda-java-events-sdk-transformer/src/main/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbAttributeValueTransformer.java
@@ -3,6 +3,7 @@ package com.amazonaws.services.lambda.runtime.events.transformers.v2.dynamodb;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -52,7 +53,7 @@ public class DynamodbAttributeValueTransformer {
         } else if (Objects.nonNull(value.getL())) {
             return AttributeValue.builder()
                     .l(value.getL().isEmpty()
-                            ? null
+                            ? Collections.emptyList()
                             : value.getL().stream()
                                 .map(DynamodbAttributeValueTransformer::toAttributeValueV2)
                                 .collect(Collectors.toList()))

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformerTest.java
@@ -303,7 +303,7 @@ class DynamodbAttributeValueTransformerTest {
     @Test
     public void testToAttributeValueV1_EmptyV1ObjectWhenEmpty_L() {
         com.amazonaws.services.dynamodbv2.model.AttributeValue expectedAttributeValue_v1 =
-                new com.amazonaws.services.dynamodbv2.model.AttributeValue();
+                new com.amazonaws.services.dynamodbv2.model.AttributeValue().withL(Collections.emptyList());
         Assertions.assertEquals(expectedAttributeValue_v1,
                 DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withL()));
         Assertions.assertEquals(expectedAttributeValue_v1,

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbAttributeValueTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbAttributeValueTransformerTest.java
@@ -307,7 +307,7 @@ class DynamodbAttributeValueTransformerTest {
     @Test
     public void testToAttributeValueV2_EmptyV2ObjectWhenEmpty_L() {
         software.amazon.awssdk.services.dynamodb.model.AttributeValue expectedAttributeValue_v2 =
-                software.amazon.awssdk.services.dynamodb.model.AttributeValue.builder().build();
+                software.amazon.awssdk.services.dynamodb.model.AttributeValue.builder().l(Collections.emptyList()).build();
         Assertions.assertEquals(expectedAttributeValue_v2,
                 DynamodbAttributeValueTransformer.toAttributeValueV2(new AttributeValue().withL()));
         Assertions.assertEquals(expectedAttributeValue_v2,


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-java-libs/issues/224

*Description of changes:* 
This change will make DynamodbAttributeValueTransformer v1 and v2 return empty list instead of null for empty list input.
Transforming empty list to `null` will break functionality for DynamoDB Enhanced library  and make it throw runtime exceptions like:
```
java.lang.IllegalStateException: Unable to convert attribute value: AttributeValue()
```
Also updated corresponding unit test cases.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
