### PR TITLE
Bump events-sdk-transformer to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>3.0.7</version>
+  <version>3.1.0</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
@@ -67,7 +67,7 @@ ___
 ```groovy
 'com.amazonaws:aws-lambda-java-core:1.2.1'
 'com.amazonaws:aws-lambda-java-events:3.11.0'
-'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.0.7'
+'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.1.0'
 'com.amazonaws:aws-lambda-java-log4j2:1.5.1'
 'com.amazonaws:aws-lambda-java-runtime-interface-client:2.1.0'
 'com.amazonaws:aws-lambda-java-tests:1.1.1'
@@ -78,7 +78,7 @@ ___
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]
 [com.amazonaws/aws-lambda-java-events "3.11.0"]
-[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.0.7"]
+[com.amazonaws/aws-lambda-java-events-sdk-transformer "3.1.0"]
 [com.amazonaws/aws-lambda-java-log4j2 "1.5.1"]
 [com.amazonaws/aws-lambda-java-runtime-interface-client "2.1.0"]
 [com.amazonaws/aws-lambda-java-tests "1.1.1"]
@@ -89,7 +89,7 @@ ___
 ```scala
 "com.amazonaws" % "aws-lambda-java-core" % "1.2.1"
 "com.amazonaws" % "aws-lambda-java-events" % "3.11.0"
-"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.0.7"
+"com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.1.0"
 "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1"
 "com.amazonaws" % "aws-lambda-java-runtime-interface-client" % "2.1.0"
 "com.amazonaws" % "aws-lambda-java-tests" % "1.1.1"

--- a/aws-lambda-java-events-sdk-transformer/README.md
+++ b/aws-lambda-java-events-sdk-transformer/README.md
@@ -16,7 +16,7 @@ Add the following Apache Maven dependencies to your `pom.xml` file:
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-        <version>3.0.7</version>
+        <version>3.1.0</version>
     </dependency>
     <dependency>
         <groupId>com.amazonaws</groupId>

--- a/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events-sdk-transformer/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### February 03, 2022
+`3.1.0`:
+-  Make DynamodbAttributeValueTransformer v1 and v2 return empty list instead of null for empty list attribute ([#309](https://github.com/aws/aws-lambda-java-libs/pull/309))
+
 ### November 24, 2021
 `3.0.7`:
 - Bumped `aws-lambda-java-events` to version `3.11.0`

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
-  <version>3.0.7</version>
+  <version>3.1.0</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Events SDK Transformer Library</name>


### PR DESCRIPTION
*Description of changes:*
Staging release:
- `aws-lambda-java-events-sdk-transformer` version `3.1.0`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
