### PR TITLE
Assert on AttributeValue List type to ensure consistency when empty and non-empty

### DIFF
--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v1/dynamodb/DynamodbAttributeValueTransformerTest.java
@@ -179,6 +179,7 @@ class DynamodbAttributeValueTransformerTest {
         com.amazonaws.services.dynamodbv2.model.AttributeValue convertedAttributeValueL =
                 DynamodbAttributeValueTransformer.toAttributeValueV1(attributeValueL_event);
         Assertions.assertEquals(attributeValueL_v1, convertedAttributeValueL);
+        Assertions.assertEquals("ArrayList", convertedAttributeValueL.getL().getClass().getSimpleName(), "List is mutable");
     }
 
     @Test
@@ -262,12 +263,14 @@ class DynamodbAttributeValueTransformerTest {
 
     @Test
     public void testToAttributeValueV1_DoesNotThrowWhenEmpty_L() {
-        Assertions.assertDoesNotThrow(() ->
-                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withL())
-        );
-        Assertions.assertDoesNotThrow(() ->
-                DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withL(Collections.emptyList()))
-        );
+        Assertions.assertDoesNotThrow(() -> {
+            com.amazonaws.services.dynamodbv2.model.AttributeValue attributeValue = DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withL());
+            Assertions.assertEquals("ArrayList", attributeValue.getL().getClass().getSimpleName(), "List is mutable");
+        });
+        Assertions.assertDoesNotThrow(() -> {
+            com.amazonaws.services.dynamodbv2.model.AttributeValue attributeValue = DynamodbAttributeValueTransformer.toAttributeValueV1(new AttributeValue().withL(Collections.emptyList()));
+            Assertions.assertEquals("ArrayList", attributeValue.getL().getClass().getSimpleName(), "List is mutable");
+        });
     }
 
     @Test

--- a/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbAttributeValueTransformerTest.java
+++ b/aws-lambda-java-events-sdk-transformer/src/test/java/com/amazonaws/services/lambda/runtime/events/transformers/v2/dynamodb/DynamodbAttributeValueTransformerTest.java
@@ -183,6 +183,7 @@ class DynamodbAttributeValueTransformerTest {
         software.amazon.awssdk.services.dynamodb.model.AttributeValue convertedAttributeValueL =
                 DynamodbAttributeValueTransformer.toAttributeValueV2(attributeValueL_event);
         Assertions.assertEquals(attributeValueL_v2, convertedAttributeValueL);
+        Assertions.assertEquals("UnmodifiableRandomAccessList", convertedAttributeValueL.l().getClass().getSimpleName(), "List is immutable");
     }
 
     @Test
@@ -266,12 +267,14 @@ class DynamodbAttributeValueTransformerTest {
 
     @Test
     public void testToAttributeValueV2_DoesNotThrowWhenEmpty_L() {
-        Assertions.assertDoesNotThrow(() ->
-                DynamodbAttributeValueTransformer.toAttributeValueV2(new AttributeValue().withL())
-        );
-        Assertions.assertDoesNotThrow(() ->
-                DynamodbAttributeValueTransformer.toAttributeValueV2(new AttributeValue().withL(Collections.emptyList()))
-        );
+        Assertions.assertDoesNotThrow(() -> {
+            software.amazon.awssdk.services.dynamodb.model.AttributeValue attributeValue = DynamodbAttributeValueTransformer.toAttributeValueV2(new AttributeValue().withL());
+            Assertions.assertEquals("UnmodifiableRandomAccessList", attributeValue.l().getClass().getSimpleName(), "List is immutable");
+        });
+        Assertions.assertDoesNotThrow(() -> {
+            software.amazon.awssdk.services.dynamodb.model.AttributeValue attributeValue = DynamodbAttributeValueTransformer.toAttributeValueV2(new AttributeValue().withL(Collections.emptyList()));
+            Assertions.assertEquals("UnmodifiableRandomAccessList", attributeValue.l().getClass().getSimpleName(), "List is immutable");
+        });
     }
 
     @Test


### PR DESCRIPTION
Following-up on https://github.com/aws/aws-lambda-java-libs/pull/309 with added assertions to ensure that returning an immutable `Collections.emptyList()` maintains a consistent behavior when using the transformer library.

The assertion ensures that the returned `List` type is consistent with the object initialized by `AttributeValue` for each SDK version (v1 uses a mutable `ArrayList` whereas v2 uses an immutable `UnmodifiableRandomAccessList`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
