### PR TITLE
version bump aws-lambda-java-runtime-interface-client 2.1.0 -> 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ___
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
 </dependency>
 <dependency>
   <groupId>com.amazonaws</groupId>
@@ -69,7 +69,7 @@ ___
 'com.amazonaws:aws-lambda-java-events:3.11.0'
 'com.amazonaws:aws-lambda-java-events-sdk-transformer:3.1.0'
 'com.amazonaws:aws-lambda-java-log4j2:1.5.1'
-'com.amazonaws:aws-lambda-java-runtime-interface-client:2.1.0'
+'com.amazonaws:aws-lambda-java-runtime-interface-client:2.1.1'
 'com.amazonaws:aws-lambda-java-tests:1.1.1'
 ```
 
@@ -80,7 +80,7 @@ ___
 [com.amazonaws/aws-lambda-java-events "3.11.0"]
 [com.amazonaws/aws-lambda-java-events-sdk-transformer "3.1.0"]
 [com.amazonaws/aws-lambda-java-log4j2 "1.5.1"]
-[com.amazonaws/aws-lambda-java-runtime-interface-client "2.1.0"]
+[com.amazonaws/aws-lambda-java-runtime-interface-client "2.1.1"]
 [com.amazonaws/aws-lambda-java-tests "1.1.1"]
 ```
 
@@ -91,7 +91,7 @@ ___
 "com.amazonaws" % "aws-lambda-java-events" % "3.11.0"
 "com.amazonaws" % "aws-lambda-java-events-sdk-transformer" % "3.1.0"
 "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1"
-"com.amazonaws" % "aws-lambda-java-runtime-interface-client" % "2.1.0"
+"com.amazonaws" % "aws-lambda-java-runtime-interface-client" % "2.1.1"
 "com.amazonaws" % "aws-lambda-java-tests" % "1.1.1"
 ```
 

--- a/aws-lambda-java-runtime-interface-client/README.md
+++ b/aws-lambda-java-runtime-interface-client/README.md
@@ -70,7 +70,7 @@ pom.xml
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-      <version>2.1.0</version>
+      <version>2.1.1</version>
     </dependency>
   </dependencies>
   <build>

--- a/aws-lambda-java-runtime-interface-client/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Runtime Interface Client</name>

--- a/aws-lambda-java-runtime-interface-client/test/integration/test-handler/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/test-handler/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-            <version>2.1.0</version>
+            <version>2.1.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
*Issue #, if available:*

related to: https://github.com/aws/aws-lambda-java-libs/issues/316

*Description of changes:*

I've staged a release to the re-build I mentioned in: https://github.com/aws/aws-lambda-java-libs/pull/325#issue-1197944312

This PR contains the version bump in the pom.xml and documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
