### PR TITLE
remove invalid link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ ___
 'com.amazonaws:aws-lambda-java-tests:1.1.1'
 ```
 
-[Leiningen](http://leiningen.org) and [Boot](http://boot-clj.com)
+[Leiningen](http://leiningen.org)
 
 ```clojure
 [com.amazonaws/aws-lambda-java-core "1.2.1"]


### PR DESCRIPTION
*Description of changes:*

Seems this has been the case for at least a year https://github.com/boot-clj/boot/issues/768! The URL currently redirects to consumerreports.review 