### PR TITLE
Fix os compatibility tests by enabling multi-platform build and testing

### DIFF
--- a/aws-lambda-java-runtime-interface-client/Makefile
+++ b/aws-lambda-java-runtime-interface-client/Makefile
@@ -1,3 +1,9 @@
+x86_64_ALIAS := amd64
+aarch64_ALIAS := arm64
+ARCHITECTURE := $(shell arch)
+ARCHITECTURE_ALIAS := $($(shell echo "$(ARCHITECTURE)_ALIAS"))
+ARCHITECTURE_ALIAS := $(or $(ARCHITECTURE_ALIAS),amd64) # on any other archs defaulting to amd64
+
 .PHONY: target
 target:
 	$(info ${HELP_MESSAGE})
@@ -9,12 +15,16 @@ test:
 
 .PHONY: setup-codebuild-agent
 setup-codebuild-agent:
-	docker build -t codebuild-agent - < test/integration/codebuild-local/Dockerfile.agent
+	docker build -t codebuild-agent \
+	 --build-arg ARCHITECTURE=$(ARCHITECTURE_ALIAS) \
+	  - < test/integration/codebuild-local/Dockerfile.agent
 
 .PHONY: test-smoke
 test-smoke: setup-codebuild-agent
-	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.alpine.yml alpine 3.12 corretto11
-	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.amazoncorretto.yml amazoncorretto amazoncorretto 11
+	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.alpine.yml alpine 3.15 corretto11 linux/amd64
+	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.alpine.yml alpine 3.15 corretto11 linux/arm64/v8
+	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.amazoncorretto.yml amazoncorretto amazoncorretto 11 linux/amd64
+	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.amazoncorretto.yml amazoncorretto amazoncorretto 11 linux/arm64/v8
 
 .PHONY: test-integ
 test-integ: setup-codebuild-agent

--- a/aws-lambda-java-runtime-interface-client/README.md
+++ b/aws-lambda-java-runtime-interface-client/README.md
@@ -24,7 +24,7 @@ The Runtime Interface Client library can be installed into the image separate fr
 Dockerfile
 ```dockerfile
 # we'll use Amazon Linux 2 + Corretto 11 as our base
-FROM amazoncorretto:11 as base
+FROM public.ecr.aws/amazoncorretto/amazoncorretto:11 as base
 
 # configure the build environment
 FROM base as build

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/Dockerfile.glibc
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/Dockerfile.glibc
@@ -1,5 +1,5 @@
 # we use centos 7 to build against glibc 2.17
-FROM centos:7
+FROM public.ecr.aws/docker/library/centos:7
 
 ARG CURL_VERSION
 

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/Dockerfile.musl
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/Dockerfile.musl
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM public.ecr.aws/docker/library/alpine:3
 
 ARG CURL_VERSION
 

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/Dockerfile.agent
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/Dockerfile.agent
@@ -1,5 +1,14 @@
 FROM public.ecr.aws/amazoncorretto/amazoncorretto:8
 
+ARG ARCHITECTURE="amd64"
+
+ENV DOCKER_CLI_PLUGIN_DIR="/root/.docker/cli-plugins"
+
 RUN amazon-linux-extras enable docker && \
     yum clean metadata && \
-    yum install -y docker tar maven unzip file
+    yum install -y docker tar maven unzip file wget
+RUN mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
+RUN wget \
+    "$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE}" | cut -d '"' -f 4)" \
+     -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+RUN chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/test_all.sh
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/test_all.sh
@@ -21,16 +21,16 @@ do_one_yaml() {
     RUNTIME_VERSIONS=$(sed '1,/RUNTIME_VERSION/d;/PLATFORM/,$d' "$YML" | sed '/#.*$/d' |  tr -d '\-" ')
     PLATFORMS=$(sed '1,/PLATFORM/d;/phases/,$d' "$YML" |  tr -d '\-" ')
 
-    for DISTRO_VERSION in $DISTRO_VERSIONS ; do
-        for RUNTIME_VERSION in $RUNTIME_VERSIONS ; do
-          for PLATFORM in $PLATFORMS ; do
-            if (( DRYRUN == 1 )) ; then
-                echo DRYRUN test_one_combination "$YML" "$OS_DISTRIBUTION" "$DISTRO_VERSION" "$RUNTIME_VERSION" "$PLATFORM"
-            else
-                test_one_combination "$YML" "$OS_DISTRIBUTION" "$DISTRO_VERSION" "$RUNTIME_VERSION" "$PLATFORM"
-            fi
+    for DISTRO_VERSION in $DISTRO_VERSIONS; do
+      for RUNTIME_VERSION in $RUNTIME_VERSIONS; do
+        for PLATFORM in $PLATFORMS; do
+          if (( DRYRUN == 1 )); then
+            echo DRYRUN test_one_combination "$YML" "$OS_DISTRIBUTION" "$DISTRO_VERSION" "$RUNTIME_VERSION" "$PLATFORM"
+          else
+            test_one_combination "$YML" "$OS_DISTRIBUTION" "$DISTRO_VERSION" "$RUNTIME_VERSION" "$PLATFORM"
+          fi
         done
-        done
+      done
     done
 }
 

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/test_all.sh
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/test_all.sh
@@ -18,15 +18,18 @@ do_one_yaml() {
 
     OS_DISTRIBUTION=$(grep -oE 'OS_DISTRIBUTION:\s*(\S+)' "$YML" | cut -d' ' -f2)
     DISTRO_VERSIONS=$(sed '1,/DISTRO_VERSION/d;/RUNTIME_VERSION/,$d' "$YML" | tr -d '\-" ')
-    RUNTIME_VERSIONS=$(sed '1,/RUNTIME_VERSION/d;/phases/,$d' "$YML" | sed '/#.*$/d' |  tr -d '\-" ')
+    RUNTIME_VERSIONS=$(sed '1,/RUNTIME_VERSION/d;/PLATFORM/,$d' "$YML" | sed '/#.*$/d' |  tr -d '\-" ')
+    PLATFORMS=$(sed '1,/PLATFORM/d;/phases/,$d' "$YML" |  tr -d '\-" ')
 
     for DISTRO_VERSION in $DISTRO_VERSIONS ; do
         for RUNTIME_VERSION in $RUNTIME_VERSIONS ; do
+          for PLATFORM in $PLATFORMS ; do
             if (( DRYRUN == 1 )) ; then
-                echo DRYRUN test_one_combination "$YML" "$OS_DISTRIBUTION" "$DISTRO_VERSION" "$RUNTIME_VERSION"
+                echo DRYRUN test_one_combination "$YML" "$OS_DISTRIBUTION" "$DISTRO_VERSION" "$RUNTIME_VERSION" "$PLATFORM"
             else
-                test_one_combination "$YML" "$OS_DISTRIBUTION" "$DISTRO_VERSION" "$RUNTIME_VERSION"
+                test_one_combination "$YML" "$OS_DISTRIBUTION" "$DISTRO_VERSION" "$RUNTIME_VERSION" "$PLATFORM"
             fi
+        done
         done
     done
 }
@@ -36,13 +39,15 @@ test_one_combination() {
     local -r OS_DISTRIBUTION="$2"
     local -r DISTRO_VERSION="$3"
     local -r RUNTIME_VERSION="$4"
-  
+    local -r PLATFORM="$5"
+    local -r PLATFORM_SANITIZED=$(echo "$PLATFORM" | tr "/" ".")
+
     echo Testing:
     echo "  BUILDSPEC" "$YML"
-    echo "  with" "$OS_DISTRIBUTION"-"$DISTRO_VERSION" "$RUNTIME_VERSION"
+    echo "  with" "$OS_DISTRIBUTION"-"$DISTRO_VERSION" "$RUNTIME_VERSION" "$PLATFORM"
 
-    "$(dirname "$0")"/test_one.sh "$YML" "$OS_DISTRIBUTION" "$DISTRO_VERSION" "$RUNTIME_VERSION" \
-        > >(sed "s/^/$OS_DISTRIBUTION$DISTRO_VERSION-$RUNTIME_VERSION: /") 2> >(sed "s/^/$OS_DISTRIBUTION-$DISTRO_VERSION:$RUNTIME_VERSION: /" >&2)
+    "$(dirname "$0")"/test_one.sh "$YML" "$OS_DISTRIBUTION" "$DISTRO_VERSION" "$RUNTIME_VERSION" "$PLATFORM" \
+        > >(sed "s/^/$OS_DISTRIBUTION$DISTRO_VERSION-$RUNTIME_VERSION-$PLATFORM_SANITIZED: /") 2> >(sed "s/^/$OS_DISTRIBUTION-$DISTRO_VERSION:$RUNTIME_VERSION:$PLATFORM_SANITIZED: /" >&2)
 }
 
 main() {

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/test_one.sh
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/test_one.sh
@@ -13,12 +13,13 @@ function usage {
     >&2 echo "  os_distribution        Used to specify the OS distribution to build."
     >&2 echo "  distro_version         Used to specify the distro version of <os_distribution>."
     >&2 echo "  runtime_version        Used to specify the runtime version to test on the selected <distro_version>."
+    >&2 echo "  platform               Used to specify the architecture platform to test on the selected <distro_version>."
     >&2 echo "Optional:"
     >&2 echo "  env                    Additional environment variables file."
 }
 
 main() {
-    if (( $# != 3 && $# != 4)); then
+    if (( $# != 5 && $# != 6)); then
         >&2 echo "Invalid number of parameters."
         usage
         exit 1
@@ -28,9 +29,11 @@ main() {
     OS_DISTRIBUTION="$2"
     DISTRO_VERSION="$3"
     RUNTIME_VERSION="$4"
-    EXTRA_ENV="${5-}"
+    PLATFORM="$5"
+    PLATFORM_SANITIZED=$(echo "$PLATFORM" | tr "/" ".")
+    EXTRA_ENV="${6-}"
 
-    CODEBUILD_TEMP_DIR=$(mktemp -d codebuild."$OS_DISTRIBUTION"-"$DISTRO_VERSION"-"$RUNTIME_VERSION".XXXXXXXXXX)
+    CODEBUILD_TEMP_DIR=$(mktemp -d codebuild."$OS_DISTRIBUTION"-"$DISTRO_VERSION"-"$RUNTIME_VERSION"-"$PLATFORM_SANITIZED".XXXXXXXXXX)
     trap 'rm -rf $CODEBUILD_TEMP_DIR' EXIT
 
     # Create an env file for codebuild_build.
@@ -43,6 +46,7 @@ main() {
         echo "OS_DISTRIBUTION=$OS_DISTRIBUTION"
         echo "DISTRO_VERSION=$DISTRO_VERSION"
         echo "RUNTIME_VERSION=$RUNTIME_VERSION"
+        echo "PLATFORM=$PLATFORM"
     }  >> "$ENVFILE"
     
     ARTIFACTS_DIR="$CODEBUILD_TEMP_DIR/artifacts"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.alpine.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.alpine.yml
@@ -4,6 +4,8 @@ env:
   variables:
     OS_DISTRIBUTION: alpine
     JAVA_BINARY_LOCATION: "/usr/bin/java"
+    DOCKER_CLI_EXPERIMENTAL: "enabled"
+    DOCKER_CLI_PLUGIN_DIR: "/root/.docker/cli-plugins"
 batch:
   build-matrix:
     static:
@@ -14,12 +16,14 @@ batch:
       env:
         variables:
           DISTRO_VERSION:
-            - "3.9"
-            - "3.10"
-            - "3.11"
-            - "3.12"
+            - "3.13"
+            - "3.14"
+            - "3.15"
           RUNTIME_VERSION:
             - "corretto11"
+          PLATFORM:
+            - "linux/amd64"
+            - "linux/arm64/v8"
 phases:
   install:
     commands:
@@ -31,6 +35,34 @@ phases:
             echo "Performing DockerHub login . . ."
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
         fi
+      - echo "Setting up multi-arch build environment"
+      - ARCHITECTURE=$(arch)
+      - >
+        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+            ARCHITECTURE_ALIAS="amd64"
+            TARGET_EMULATOR="arm64"
+        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+            ARCHITECTURE_ALIAS="arm64"
+            TARGET_EMULATOR="amd64"
+        else
+            echo "Architecture $ARCHITECTURE is not currently supported."
+            exit 1
+        fi
+      - echo "Installing ${TARGET_EMULATOR} emulator"
+      - docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
+      - docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
+      # Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
+      - >
+        if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; 
+        then
+            echo "docker-buildx not found, installing now"
+            mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
+            export BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
+            wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+            chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+        fi
+      - echo "Setting docker build command to default to buildx"
+      - docker buildx install
   pre_build:
     commands:
       # Log some environment variables for troubleshooting
@@ -39,20 +71,19 @@ phases:
       - (cd aws-lambda-java-events && mvn install)
       # Install serialization (dependency of RIC)
       - (cd aws-lambda-java-serialization && mvn install)
-      - (cd aws-lambda-java-runtime-interface-client && mvn install -DmultiArch=false)
+      - (cd aws-lambda-java-runtime-interface-client && mvn install)
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)
       - export IMAGE_TAG="java-${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION}"
       - echo "Extracting and including Runtime Interface Emulator"
       - SCRATCH_DIR=".scratch"
       - mkdir "${SCRATCH_DIR}"
-      - ARCHITECTURE=$(arch)
       - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+        if [[ "$PLATFORM" == "linux/amd64" ]]; then
             RIE="aws-lambda-rie"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+        elif [[ "$PLATFORM" == "linux/arm64/v8" ]]; then
             RIE="aws-lambda-rie-arm64"
         else
-            echo "Architecture $ARCHITECTURE is not currently supported."
+            echo "Platform $PLATFORM is not currently supported."
             exit 1
         fi
       - tar -xvf aws-lambda-java-runtime-interface-client/test/integration/resources/${RIE}.tar.gz --directory "${SCRATCH_DIR}"
@@ -70,6 +101,7 @@ phases:
         docker build . \
           -f "${SCRATCH_DIR}/Dockerfile.function.${OS_DISTRIBUTION}.tmp" \
           -t "${IMAGE_TAG}" \
+          --platform="${PLATFORM}" \
           --build-arg RUNTIME_VERSION="${RUNTIME_VERSION}" \
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.alpine.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.alpine.yml
@@ -35,34 +35,7 @@ phases:
             echo "Performing DockerHub login . . ."
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
         fi
-      - echo "Setting up multi-arch build environment"
-      - ARCHITECTURE=$(arch)
-      - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-            ARCHITECTURE_ALIAS="amd64"
-            TARGET_EMULATOR="arm64"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
-            ARCHITECTURE_ALIAS="arm64"
-            TARGET_EMULATOR="amd64"
-        else
-            echo "Architecture $ARCHITECTURE is not currently supported."
-            exit 1
-        fi
-      - echo "Installing ${TARGET_EMULATOR} emulator"
-      - docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
-      - docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
-      # Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
-      - >
-        if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; 
-        then
-            echo "docker-buildx not found, installing now"
-            mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
-            export BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
-            wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-            chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-        fi
-      - echo "Setting docker build command to default to buildx"
-      - docker buildx install
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/configure_multi_arch_env.sh
   pre_build:
     commands:
       # Log some environment variables for troubleshooting

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazoncorretto.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazoncorretto.yml
@@ -34,34 +34,7 @@ phases:
             echo "Performing DockerHub login . . ."
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
         fi
-      - echo "Setting up multi-arch build environment"
-      - ARCHITECTURE=$(arch)
-      - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-            ARCHITECTURE_ALIAS="amd64"
-            TARGET_EMULATOR="arm64"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
-            ARCHITECTURE_ALIAS="arm64"
-            TARGET_EMULATOR="amd64"
-        else
-            echo "Architecture $ARCHITECTURE is not currently supported."
-            exit 1
-        fi
-      - echo "Installing ${TARGET_EMULATOR} emulator"
-      - docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
-      - docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
-      # Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
-      - >
-        if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; 
-        then
-            echo "docker-buildx not found, installing now"
-            mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
-            export BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
-            wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-            chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-        fi
-      - echo "Setting docker build command to default to buildx"
-      - docker buildx install
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/configure_multi_arch_env.sh
   pre_build:
     commands:
       # Log some environment variables for troubleshooting

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazoncorretto.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazoncorretto.yml
@@ -4,6 +4,8 @@ env:
   variables:
     OS_DISTRIBUTION: amazoncorretto
     JAVA_BINARY_LOCATION: "/usr/bin/java"
+    DOCKER_CLI_EXPERIMENTAL: "enabled"
+    DOCKER_CLI_PLUGIN_DIR: "/root/.docker/cli-plugins"
 batch:
   build-matrix:
     static:
@@ -18,6 +20,9 @@ batch:
           RUNTIME_VERSION:
             - "8"
             - "11"
+          PLATFORM:
+            - "linux/amd64"
+            - "linux/arm64/v8"
 phases:
   install:
     commands:
@@ -29,6 +34,34 @@ phases:
             echo "Performing DockerHub login . . ."
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
         fi
+      - echo "Setting up multi-arch build environment"
+      - ARCHITECTURE=$(arch)
+      - >
+        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+            ARCHITECTURE_ALIAS="amd64"
+            TARGET_EMULATOR="arm64"
+        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+            ARCHITECTURE_ALIAS="arm64"
+            TARGET_EMULATOR="amd64"
+        else
+            echo "Architecture $ARCHITECTURE is not currently supported."
+            exit 1
+        fi
+      - echo "Installing ${TARGET_EMULATOR} emulator"
+      - docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
+      - docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
+      # Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
+      - >
+        if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; 
+        then
+            echo "docker-buildx not found, installing now"
+            mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
+            export BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
+            wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+            chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+        fi
+      - echo "Setting docker build command to default to buildx"
+      - docker buildx install
   pre_build:
     commands:
       # Log some environment variables for troubleshooting
@@ -37,20 +70,19 @@ phases:
       - (cd aws-lambda-java-events && mvn install)
       # Install serialization (dependency of RIC)
       - (cd aws-lambda-java-serialization && mvn install)
-      - (cd aws-lambda-java-runtime-interface-client && mvn install -DmultiArch=false)
+      - (cd aws-lambda-java-runtime-interface-client && mvn install)
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)
       - export IMAGE_TAG="java-${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION}"
       - echo "Extracting and including Runtime Interface Emulator"
       - SCRATCH_DIR=".scratch"
       - mkdir "${SCRATCH_DIR}"
-      - ARCHITECTURE=$(arch)
       - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+        if [[ "$PLATFORM" == "linux/amd64" ]]; then
             RIE="aws-lambda-rie"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+        elif [[ "$PLATFORM" == "linux/arm64/v8" ]]; then
             RIE="aws-lambda-rie-arm64"
         else
-            echo "Architecture $ARCHITECTURE is not currently supported."
+            echo "Platform $PLATFORM is not currently supported."
             exit 1
         fi
       - tar -xvf aws-lambda-java-runtime-interface-client/test/integration/resources/${RIE}.tar.gz --directory "${SCRATCH_DIR}"
@@ -65,6 +97,7 @@ phases:
         docker build . \
           -f "${SCRATCH_DIR}/Dockerfile.function.${OS_DISTRIBUTION}.tmp" \
           -t "${IMAGE_TAG}" \
+          --platform="${PLATFORM}" \
           --build-arg RUNTIME_VERSION="${RUNTIME_VERSION}" \
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.1.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.1.yml
@@ -17,6 +17,8 @@ batch:
             - "1"
           RUNTIME_VERSION:
             - "openjdk8"
+          PLATFORM:
+            - "linux/amd64"
 phases:
   install:
     commands:
@@ -36,22 +38,13 @@ phases:
       - (cd aws-lambda-java-events && mvn install)
       # Install serialization (dependency of RIC)
       - (cd aws-lambda-java-serialization && mvn install)
-      - (cd aws-lambda-java-runtime-interface-client && mvn install)
+      - (cd aws-lambda-java-runtime-interface-client && mvn install -DmultiArch=false)
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)
       - export IMAGE_TAG="java-${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION}"
       - echo "Extracting and including Runtime Interface Emulator"
       - SCRATCH_DIR=".scratch"
       - mkdir "${SCRATCH_DIR}"
-      - ARCHITECTURE=$(arch)
-      - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-            RIE="aws-lambda-rie"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
-            RIE="aws-lambda-rie-arm64"
-        else
-            echo "Architecture $ARCHITECTURE is not currently supported."
-            exit 1
-        fi
+      - RIE="aws-lambda-rie"
       - tar -xvf aws-lambda-java-runtime-interface-client/test/integration/resources/${RIE}.tar.gz --directory "${SCRATCH_DIR}"
       - >
         cp "aws-lambda-java-runtime-interface-client/test/integration/docker/Dockerfile.function.${OS_DISTRIBUTION}" \

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.2.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.2.yml
@@ -33,34 +33,7 @@ phases:
             echo "Performing DockerHub login . . ."
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
         fi
-      - echo "Setting up multi-arch build environment"
-      - ARCHITECTURE=$(arch)
-      - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-            ARCHITECTURE_ALIAS="amd64"
-            TARGET_EMULATOR="arm64"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
-            ARCHITECTURE_ALIAS="arm64"
-            TARGET_EMULATOR="amd64"
-        else
-            echo "Architecture $ARCHITECTURE is not currently supported."
-            exit 1
-        fi
-      - echo "Installing ${TARGET_EMULATOR} emulator"
-      - docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
-      - docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
-      # Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
-      - >
-        if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; 
-        then
-            echo "docker-buildx not found, installing now"
-            mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
-            export BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
-            wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-            chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-        fi
-      - echo "Setting docker build command to default to buildx"
-      - docker buildx install
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/configure_multi_arch_env.sh
   pre_build:
     commands:
       # Log some environment variables for troubleshooting

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.2.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.2.yml
@@ -4,6 +4,8 @@ env:
   variables:
     OS_DISTRIBUTION: amazonlinux
     JAVA_BINARY_LOCATION: "/usr/bin/java"
+    DOCKER_CLI_EXPERIMENTAL: "enabled"
+    DOCKER_CLI_PLUGIN_DIR: "/root/.docker/cli-plugins"
 batch:
   build-matrix:
     static:
@@ -17,6 +19,9 @@ batch:
             - "2"
           RUNTIME_VERSION:
             - "openjdk8"
+          PLATFORM:
+            - "linux/amd64"
+            - "linux/arm64/v8"
 phases:
   install:
     commands:
@@ -28,6 +33,34 @@ phases:
             echo "Performing DockerHub login . . ."
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
         fi
+      - echo "Setting up multi-arch build environment"
+      - ARCHITECTURE=$(arch)
+      - >
+        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+            ARCHITECTURE_ALIAS="amd64"
+            TARGET_EMULATOR="arm64"
+        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+            ARCHITECTURE_ALIAS="arm64"
+            TARGET_EMULATOR="amd64"
+        else
+            echo "Architecture $ARCHITECTURE is not currently supported."
+            exit 1
+        fi
+      - echo "Installing ${TARGET_EMULATOR} emulator"
+      - docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
+      - docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
+      # Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
+      - >
+        if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; 
+        then
+            echo "docker-buildx not found, installing now"
+            mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
+            export BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
+            wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+            chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+        fi
+      - echo "Setting docker build command to default to buildx"
+      - docker buildx install
   pre_build:
     commands:
       # Log some environment variables for troubleshooting
@@ -42,14 +75,13 @@ phases:
       - echo "Extracting and including Runtime Interface Emulator"
       - SCRATCH_DIR=".scratch"
       - mkdir "${SCRATCH_DIR}"
-      - ARCHITECTURE=$(arch)
       - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+        if [[ "$PLATFORM" == "linux/amd64" ]]; then
             RIE="aws-lambda-rie"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+        elif [[ "$PLATFORM" == "linux/arm64/v8" ]]; then
             RIE="aws-lambda-rie-arm64"
         else
-            echo "Architecture $ARCHITECTURE is not currently supported."
+            echo "Platform $PLATFORM is not currently supported."
             exit 1
         fi
       - tar -xvf aws-lambda-java-runtime-interface-client/test/integration/resources/${RIE}.tar.gz --directory "${SCRATCH_DIR}"
@@ -64,6 +96,7 @@ phases:
         docker build . \
           -f "${SCRATCH_DIR}/Dockerfile.function.${OS_DISTRIBUTION}.tmp" \
           -t "${IMAGE_TAG}" \
+          --platform="${PLATFORM}" \
           --build-arg RUNTIME_VERSION="${RUNTIME_VERSION}" \
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.centos.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.centos.yml
@@ -33,34 +33,7 @@ phases:
             echo "Performing DockerHub login . . ."
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
         fi
-      - echo "Setting up multi-arch build environment"
-      - ARCHITECTURE=$(arch)
-      - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-            ARCHITECTURE_ALIAS="amd64"
-            TARGET_EMULATOR="arm64"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
-            ARCHITECTURE_ALIAS="arm64"
-            TARGET_EMULATOR="amd64"
-        else
-            echo "Architecture $ARCHITECTURE is not currently supported."
-            exit 1
-        fi
-      - echo "Installing ${TARGET_EMULATOR} emulator"
-      - docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
-      - docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
-      # Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
-      - >
-        if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; 
-        then
-            echo "docker-buildx not found, installing now"
-            mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
-            export BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
-            wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-            chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-        fi
-      - echo "Setting docker build command to default to buildx"
-      - docker buildx install
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/configure_multi_arch_env.sh
   pre_build:
     commands:
       # Log some environment variables for troubleshooting

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.centos.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.centos.yml
@@ -4,6 +4,8 @@ env:
   variables:
     OS_DISTRIBUTION: centos
     JAVA_BINARY_LOCATION: "/usr/bin/java"
+    DOCKER_CLI_EXPERIMENTAL: "enabled"
+    DOCKER_CLI_PLUGIN_DIR: "/root/.docker/cli-plugins"
 batch:
   build-matrix:
     static:
@@ -15,9 +17,11 @@ batch:
         variables:
           DISTRO_VERSION:
             - "7"
-            - "8"
           RUNTIME_VERSION:
             - "corretto11"
+          PLATFORM:
+            - "linux/amd64"
+            - "linux/arm64/v8"
 phases:
   install:
     commands:
@@ -29,6 +33,34 @@ phases:
             echo "Performing DockerHub login . . ."
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
         fi
+      - echo "Setting up multi-arch build environment"
+      - ARCHITECTURE=$(arch)
+      - >
+        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+            ARCHITECTURE_ALIAS="amd64"
+            TARGET_EMULATOR="arm64"
+        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+            ARCHITECTURE_ALIAS="arm64"
+            TARGET_EMULATOR="amd64"
+        else
+            echo "Architecture $ARCHITECTURE is not currently supported."
+            exit 1
+        fi
+      - echo "Installing ${TARGET_EMULATOR} emulator"
+      - docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
+      - docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
+      # Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
+      - >
+        if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; 
+        then
+            echo "docker-buildx not found, installing now"
+            mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
+            export BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
+            wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+            chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+        fi
+      - echo "Setting docker build command to default to buildx"
+      - docker buildx install
   pre_build:
     commands:
       # Log some environment variables for troubleshooting
@@ -43,14 +75,13 @@ phases:
       - echo "Extracting and including Runtime Interface Emulator"
       - SCRATCH_DIR=".scratch"
       - mkdir "${SCRATCH_DIR}"
-      - ARCHITECTURE=$(arch)
       - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+        if [[ "$PLATFORM" == "linux/amd64" ]]; then
             RIE="aws-lambda-rie"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+        elif [[ "$PLATFORM" == "linux/arm64/v8" ]]; then
             RIE="aws-lambda-rie-arm64"
         else
-            echo "Architecture $ARCHITECTURE is not currently supported."
+            echo "Platform $PLATFORM is not currently supported."
             exit 1
         fi
       - tar -xvf aws-lambda-java-runtime-interface-client/test/integration/resources/${RIE}.tar.gz --directory "${SCRATCH_DIR}"
@@ -65,6 +96,7 @@ phases:
         docker build . \
           -f "${SCRATCH_DIR}/Dockerfile.function.${OS_DISTRIBUTION}.tmp" \
           -t "${IMAGE_TAG}" \
+          --platform="${PLATFORM}" \
           --build-arg RUNTIME_VERSION="${RUNTIME_VERSION}" \
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.debian.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.debian.yml
@@ -34,34 +34,7 @@ phases:
             echo "Performing DockerHub login . . ."
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
         fi
-      - echo "Setting up multi-arch build environment"
-      - ARCHITECTURE=$(arch)
-      - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-            ARCHITECTURE_ALIAS="amd64"
-            TARGET_EMULATOR="arm64"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
-            ARCHITECTURE_ALIAS="arm64"
-            TARGET_EMULATOR="amd64"
-        else
-            echo "Architecture $ARCHITECTURE is not currently supported."
-            exit 1
-        fi
-      - echo "Installing ${TARGET_EMULATOR} emulator"
-      - docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
-      - docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
-      # Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
-      - >
-        if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; 
-        then
-            echo "docker-buildx not found, installing now"
-            mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
-            export BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
-            wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-            chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-        fi
-      - echo "Setting docker build command to default to buildx"
-      - docker buildx install
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/configure_multi_arch_env.sh
   pre_build:
     commands:
       # Log some environment variables for troubleshooting

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.debian.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.debian.yml
@@ -4,6 +4,8 @@ env:
   variables:
     OS_DISTRIBUTION: debian
     JAVA_BINARY_LOCATION: "/usr/lib/jvm/java-11-amazon-corretto/bin/java"
+    DOCKER_CLI_EXPERIMENTAL: "enabled"
+    DOCKER_CLI_PLUGIN_DIR: "/root/.docker/cli-plugins"
 batch:
   build-matrix:
     static:
@@ -15,8 +17,12 @@ batch:
         variables:
           DISTRO_VERSION:
             - "buster"
+            - "bullseye"
           RUNTIME_VERSION:
             - "corretto11"
+          PLATFORM:
+            - "linux/amd64"
+            - "linux/arm64/v8"
 phases:
   install:
     commands:
@@ -28,6 +34,34 @@ phases:
             echo "Performing DockerHub login . . ."
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
         fi
+      - echo "Setting up multi-arch build environment"
+      - ARCHITECTURE=$(arch)
+      - >
+        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+            ARCHITECTURE_ALIAS="amd64"
+            TARGET_EMULATOR="arm64"
+        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+            ARCHITECTURE_ALIAS="arm64"
+            TARGET_EMULATOR="amd64"
+        else
+            echo "Architecture $ARCHITECTURE is not currently supported."
+            exit 1
+        fi
+      - echo "Installing ${TARGET_EMULATOR} emulator"
+      - docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
+      - docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
+      # Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
+      - >
+        if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; 
+        then
+            echo "docker-buildx not found, installing now"
+            mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
+            export BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
+            wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+            chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+        fi
+      - echo "Setting docker build command to default to buildx"
+      - docker buildx install
   pre_build:
     commands:
       # Log some environment variables for troubleshooting
@@ -42,14 +76,13 @@ phases:
       - echo "Extracting and including Runtime Interface Emulator"
       - SCRATCH_DIR=".scratch"
       - mkdir "${SCRATCH_DIR}"
-      - ARCHITECTURE=$(arch)
       - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+        if [[ "$PLATFORM" == "linux/amd64" ]]; then
             RIE="aws-lambda-rie"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+        elif [[ "$PLATFORM" == "linux/arm64/v8" ]]; then
             RIE="aws-lambda-rie-arm64"
         else
-            echo "Architecture $ARCHITECTURE is not currently supported."
+            echo "Platform $PLATFORM is not currently supported."
             exit 1
         fi
       - tar -xvf aws-lambda-java-runtime-interface-client/test/integration/resources/${RIE}.tar.gz --directory "${SCRATCH_DIR}"
@@ -67,6 +100,7 @@ phases:
         docker build . \
           -f "${SCRATCH_DIR}/Dockerfile.function.${OS_DISTRIBUTION}.tmp" \
           -t "${IMAGE_TAG}" \
+          --platform="${PLATFORM}" \
           --build-arg RUNTIME_VERSION="${RUNTIME_VERSION}" \
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.ubuntu.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.ubuntu.yml
@@ -36,34 +36,7 @@ phases:
             echo "Performing DockerHub login . . ."
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
         fi
-      - echo "Setting up multi-arch build environment"
-      - ARCHITECTURE=$(arch)
-      - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-            ARCHITECTURE_ALIAS="amd64"
-            TARGET_EMULATOR="arm64"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
-            ARCHITECTURE_ALIAS="arm64"
-            TARGET_EMULATOR="amd64"
-        else
-            echo "Architecture $ARCHITECTURE is not currently supported."
-            exit 1
-        fi
-      - echo "Installing ${TARGET_EMULATOR} emulator"
-      - docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
-      - docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
-      # Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
-      - >
-        if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; 
-        then
-            echo "docker-buildx not found, installing now"
-            mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
-            export BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
-            wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-            chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-        fi
-      - echo "Setting docker build command to default to buildx"
-      - docker buildx install
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/configure_multi_arch_env.sh
   pre_build:
     commands:
       # Log some environment variables for troubleshooting
@@ -78,7 +51,6 @@ phases:
       - echo "Extracting and including Runtime Interface Emulator"
       - SCRATCH_DIR=".scratch"
       - mkdir "${SCRATCH_DIR}"
-      - ARCHITECTURE=$(arch)
       - >
         if [[ "$PLATFORM" == "linux/amd64" ]]; then
             RIE="aws-lambda-rie"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.ubuntu.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.ubuntu.yml
@@ -4,6 +4,8 @@ env:
   variables:
     OS_DISTRIBUTION: ubuntu
     JAVA_BINARY_LOCATION: "/usr/lib/jvm/java-11-amazon-corretto/bin/java"
+    DOCKER_CLI_EXPERIMENTAL: "enabled"
+    DOCKER_CLI_PLUGIN_DIR: "/root/.docker/cli-plugins"
 batch:
   build-matrix:
     static:
@@ -14,11 +16,15 @@ batch:
       env:
         variables:
           DISTRO_VERSION:
-            - "16.04"
             - "18.04"
             - "20.04"
+            - "21.10"
+            - "22.04"
           RUNTIME_VERSION:
             - "corretto11"
+          PLATFORM:
+            - "linux/amd64"
+            - "linux/arm64/v8"
 phases:
   install:
     commands:
@@ -30,6 +36,34 @@ phases:
             echo "Performing DockerHub login . . ."
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
         fi
+      - echo "Setting up multi-arch build environment"
+      - ARCHITECTURE=$(arch)
+      - >
+        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+            ARCHITECTURE_ALIAS="amd64"
+            TARGET_EMULATOR="arm64"
+        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+            ARCHITECTURE_ALIAS="arm64"
+            TARGET_EMULATOR="amd64"
+        else
+            echo "Architecture $ARCHITECTURE is not currently supported."
+            exit 1
+        fi
+      - echo "Installing ${TARGET_EMULATOR} emulator"
+      - docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
+      - docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
+      # Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
+      - >
+        if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; 
+        then
+            echo "docker-buildx not found, installing now"
+            mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
+            export BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
+            wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+            chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+        fi
+      - echo "Setting docker build command to default to buildx"
+      - docker buildx install
   pre_build:
     commands:
       # Log some environment variables for troubleshooting
@@ -46,12 +80,12 @@ phases:
       - mkdir "${SCRATCH_DIR}"
       - ARCHITECTURE=$(arch)
       - >
-        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+        if [[ "$PLATFORM" == "linux/amd64" ]]; then
             RIE="aws-lambda-rie"
-        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+        elif [[ "$PLATFORM" == "linux/arm64/v8" ]]; then
             RIE="aws-lambda-rie-arm64"
         else
-            echo "Architecture $ARCHITECTURE is not currently supported."
+            echo "Platform $PLATFORM is not currently supported."
             exit 1
         fi
       - tar -xvf aws-lambda-java-runtime-interface-client/test/integration/resources/${RIE}.tar.gz --directory "${SCRATCH_DIR}"
@@ -69,6 +103,7 @@ phases:
         docker build . \
           -f "${SCRATCH_DIR}/Dockerfile.function.${OS_DISTRIBUTION}.tmp" \
           -t "${IMAGE_TAG}" \
+          --platform="${PLATFORM}" \
           --build-arg RUNTIME_VERSION="${RUNTIME_VERSION}" \
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/configure_multi_arch_env.sh
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/configure_multi_arch_env.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+set -euo pipefail
+
+echo "Setting up multi-arch build environment"
+ARCHITECTURE=$(arch)
+if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+	ARCHITECTURE_ALIAS="amd64"
+	TARGET_EMULATOR="arm64"
+elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+	ARCHITECTURE_ALIAS="arm64"
+	TARGET_EMULATOR="amd64"
+else
+	echo "Architecture $ARCHITECTURE is not currently supported."
+	exit 1
+fi
+echo "Installing ${TARGET_EMULATOR} emulator"
+docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
+docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
+# Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
+if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; then
+	echo "docker-buildx not found, installing now"
+	mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
+	BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
+	wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+	chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+fi
+echo "Setting docker build command to default to buildx"
+docker buildx install

--- a/aws-lambda-java-runtime-interface-client/test/integration/docker/Dockerfile.function.alpine
+++ b/aws-lambda-java-runtime-interface-client/test/integration/docker/Dockerfile.function.alpine
@@ -1,6 +1,6 @@
 ARG DISTRO_VERSION
 
-FROM alpine:${DISTRO_VERSION}
+FROM public.ecr.aws/docker/library/alpine:${DISTRO_VERSION}
 
 RUN apk update && \
     apk add openjdk8

--- a/aws-lambda-java-runtime-interface-client/test/integration/docker/Dockerfile.function.amazonlinux
+++ b/aws-lambda-java-runtime-interface-client/test/integration/docker/Dockerfile.function.amazonlinux
@@ -1,6 +1,6 @@
 ARG DISTRO_VERSION
 
-FROM amazonlinux:${DISTRO_VERSION}
+FROM public.ecr.aws/amazonlinux/amazonlinux:${DISTRO_VERSION}
 
 RUN yum install -y java-1.8.0-openjdk
 

--- a/aws-lambda-java-runtime-interface-client/test/integration/docker/Dockerfile.function.centos
+++ b/aws-lambda-java-runtime-interface-client/test/integration/docker/Dockerfile.function.centos
@@ -1,6 +1,6 @@
 ARG DISTRO_VERSION
 
-FROM centos:${DISTRO_VERSION}
+FROM public.ecr.aws/docker/library/centos:centos${DISTRO_VERSION}
 
 RUN rpm --import https://yum.corretto.aws/corretto.key  && \
     curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo  && \

--- a/aws-lambda-java-runtime-interface-client/test/integration/docker/Dockerfile.function.debian
+++ b/aws-lambda-java-runtime-interface-client/test/integration/docker/Dockerfile.function.debian
@@ -1,6 +1,6 @@
 ARG DISTRO_VERSION
 
-FROM debian:${DISTRO_VERSION} as build-image
+FROM public.ecr.aws/debian/debian:${DISTRO_VERSION} as build-image
 
 RUN apt-get update && \
     apt-get install -y wget gpg software-properties-common && \
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y java-11-amazon-corretto-jdk
 
-FROM debian:${DISTRO_VERSION}
+FROM public.ecr.aws/debian/debian:${DISTRO_VERSION}
     
 COPY --from=build-image /usr/lib/jvm /usr/lib/jvm
 

--- a/aws-lambda-java-runtime-interface-client/test/integration/docker/Dockerfile.function.ubuntu
+++ b/aws-lambda-java-runtime-interface-client/test/integration/docker/Dockerfile.function.ubuntu
@@ -1,6 +1,6 @@
 ARG DISTRO_VERSION
 
-FROM ubuntu:${DISTRO_VERSION} as build-image
+FROM public.ecr.aws/ubuntu/ubuntu:${DISTRO_VERSION} as build-image
 
 RUN apt-get update && \
     apt-get install -y apt-transport-https ca-certificates && \
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y java-11-amazon-corretto-jdk
 
-FROM ubuntu:${DISTRO_VERSION}
+FROM public.ecr.aws/ubuntu/ubuntu:${DISTRO_VERSION}
 
 COPY --from=build-image /usr/lib/jvm /usr/lib/jvm
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**Enable multi-arch testing**

Currently compatibility tests are failing when trying to build multi-arch JNI libs:

```
Build JNI libraries:
     [exec] Compiling the native library for target glibc on architecture x86_64 using Docker platform linux/amd64
     [exec] The command '/bin/sh -c rpm --import https://yum.corretto.aws/corretto.key &&     curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo' returned a non-zero code: 1
     [exec] tar: This does not look like a tar archive
     [exec] tar: Skipping to next header
     [exec] tar: src/aws-lambda-runtime-interface-client.so: Not found in archive
     [exec] tar: Exiting with failure status due to previous errors
```
* set up a multi-arch build environment prior to building the Runtime Interface Client and running the tests:
  * install necessary emulator,
  * install docker-buildx plugin
* reenable multi-arch RIC build on alpine and amazoncorretto distros
* add `PLATFORM` to the build matrix, build platform specific test images and run integ tests for both x86_64 and arm64
* run smoke tests for both x86_64 and arm64
* disable multi-arch RIC build on AL1 (available only for x86_64) 

**Clean up EOL/ESM os versions from os compatibility tests**
* clean up EOL oss:
  * alpine 3.9, 3.10, 3.11, 3.12 
  * centos 8
  * ubuntu 16.04 (ESM)
* add more recent versions
  * alpine 3.13, 3.14, 3.15
  * debian bullseye
  * ubuntu 21.10, 22.04 

**Source base images from Amazon ECR Public**

* pull test and build images from Amazon ECR Public instead of Docker Hub (some of the images were already sourced from public ECR)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
