### PR TITLE
Use correct package name prefix of 'NativeClient' class

### DIFF
--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/ClasspathLoader.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/ClasspathLoader.java
@@ -19,13 +19,13 @@ import java.util.jar.JarFile;
  */
 public class ClasspathLoader {
 
-    private static final Set<String> BLACKLIST = new HashSet<>();
+    private static final Set<String> BLOCKLIST = new HashSet<>();
     private static final ClassLoader SYSTEM_CLASS_LOADER = ClassLoader.getSystemClassLoader();
     private static final int CLASS_SUFFIX_LEN = ".class".length();
 
     static {
         // NativeClient loads a native library and crashes if loaded here so just exclude it
-        BLACKLIST.add("lambdainternal.runtimeapi.NativeClient");
+        BLOCKLIST.add("com.amazonaws.services.lambda.runtime.api.client.runtimeapi.NativeClient");
     }
 
     private static String pathToClassName(final String path) {
@@ -52,7 +52,7 @@ public class ClasspathLoader {
 
             String name = pathToClassName(entry.getName());
 
-            if(BLACKLIST.contains(name)) {
+            if(BLOCKLIST.contains(name)) {
                 continue;
             }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* use correct package name prefix of `NativeClient` class ([see](https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/NativeClient.java)): 

`lambdainternal.runtimeapi` -> `com.amazonaws.services.lambda.runtime.api.client.runtimeapi`

* use inclusive language.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
