### PR TITLE
Fix os compatibility test local builds on arm64 hosts

### DIFF
--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/codebuild_build.sh
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/codebuild_build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file is copied from https://github.com/aws/aws-codebuild-docker-images/blob/f0912e4b16e427da35351fc102f0f56f4ceb938a/local_builds/codebuild_build.sh
+# This file is copied from https://github.com/aws/aws-codebuild-docker-images/blob/282c6634e8c83c2a9841719b09aabfced3461981/local_builds/codebuild_build.sh
 
 function allOSRealPath() {
     if isOSWindows
@@ -36,6 +36,7 @@ function usage {
     echo "  -a        Used to specify an artifact output directory."
     echo "Options:"
     echo "  -l IMAGE  Used to override the default local agent image."
+    echo "  -r        Used to specify a report output directory."
     echo "  -s        Used to specify source information. Defaults to the current working directory for primary source."
     echo "               * First (-s) is for primary source"
     echo "               * Use additional (-s) in <sourceIdentifier>:<sourceLocation> format for secondary source"
@@ -61,10 +62,11 @@ awsconfig_flag=false
 mount_src_dir_flag=false
 docker_privileged_mode_flag=false
 
-while getopts "cmdi:a:s:b:e:l:p:h" opt; do
+while getopts "cmdi:a:r:s:b:e:l:p:h" opt; do
     case $opt in
         i  ) image_flag=true; image_name=$OPTARG;;
         a  ) artifact_flag=true; artifact_dir=$OPTARG;;
+        r  ) report_dir=$OPTARG;;
         b  ) buildspec=$OPTARG;;
         c  ) awsconfig_flag=true;;
         m  ) mount_src_dir_flag=true;;
@@ -95,7 +97,7 @@ then
     exit 1
 fi
 
-docker_command="docker run "
+docker_command="docker run -it "
 if isOSWindows
 then
     docker_command+="-v //var/run/docker.sock:/var/run/docker.sock -e "
@@ -105,6 +107,11 @@ fi
 
 docker_command+="\"IMAGE_NAME=$image_name\" -e \
     \"ARTIFACTS=$(allOSRealPath "$artifact_dir")\""
+
+if [ -n "$report_dir" ]
+then
+    docker_command+=" -e \"REPORTS=$(allOSRealPath "$report_dir")\""
+fi
 
 if [ -z "$source_dirs" ]
 then
@@ -176,7 +183,12 @@ else
     docker_command+=" -e \"INITIATOR=$USER\""
 fi
 
-docker_command+=" public.ecr.aws/codebuild/local-builds:latest"
+if [ -n "$local_agent_image" ]
+then
+    docker_command+=" $local_agent_image"
+else
+    docker_command+=" public.ecr.aws/codebuild/local-builds:latest"
+fi
 
 # Note we do not expose the AWS_SECRET_ACCESS_KEY or the AWS_SESSION_TOKEN
 exposed_command=$docker_command

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/test_one.sh
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/test_one.sh
@@ -18,6 +18,15 @@ function usage {
     >&2 echo "  env                    Additional environment variables file."
 }
 
+# codebuild/local-builds images are not multi-architectural
+function get_local_agent_image() {
+    if [[ "$(arch)" == "aarch64" ]]; then
+        echo "public.ecr.aws/codebuild/local-builds:aarch64"
+    else
+        echo "public.ecr.aws/codebuild/local-builds:latest"
+    fi
+}
+
 main() {
     if (( $# != 5 && $# != 6)); then
         >&2 echo "Invalid number of parameters."
@@ -48,7 +57,7 @@ main() {
         echo "RUNTIME_VERSION=$RUNTIME_VERSION"
         echo "PLATFORM=$PLATFORM"
     }  >> "$ENVFILE"
-    
+
     ARTIFACTS_DIR="$CODEBUILD_TEMP_DIR/artifacts"
     mkdir -p "$ARTIFACTS_DIR"
     # Run CodeBuild local agent.
@@ -57,7 +66,8 @@ main() {
         -a "$ARTIFACTS_DIR" \
         -e "$ENVFILE" \
         -b "$BUILDSPEC_YML" \
-        -s "$(dirname $PWD)"
+        -s "$(dirname $PWD)" \
+        -l "$(get_local_agent_image)"
 }
 
 main "$@"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.alpine.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.alpine.yml
@@ -79,34 +79,7 @@ phases:
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:
     commands:
-      - set -x
-      - echo "Running Image ${IMAGE_TAG}"
-      - docker network create "${OS_DISTRIBUTION}-network"
-      - >
-        docker run \
-          --detach \
-          --name "${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c "/usr/bin/${RIE} ${JAVA_BINARY_LOCATION} -jar ./HelloWorld-1.0.jar helloworld.App"
-      - sleep 2
-      - >
-        docker run \
-          --name "${OS_DISTRIBUTION}-tester" \
-          --env "TARGET=${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c 'curl -X POST "http://${TARGET}:8080/2015-03-31/functions/function/invocations" -d "{}" --max-time 10'
-      - actual="$(docker logs --tail 1 "${OS_DISTRIBUTION}-tester" | xargs)"
-      - expected='success'
-      - |
-        echo "Response: ${actual}"
-        if [[ "$actual" != "$expected" ]]; then
-          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
-          exit -1
-        fi
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/run_invocation_test.sh
     finally:
       - |
         echo "---------Container Logs: ${OS_DISTRIBUTION}-app----------"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazoncorretto.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazoncorretto.yml
@@ -75,34 +75,7 @@ phases:
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:
     commands:
-      - set -x
-      - echo "Running Image ${IMAGE_TAG}"
-      - docker network create "${OS_DISTRIBUTION}-network"
-      - >
-        docker run \
-          --detach \
-          --name "${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c "/usr/bin/${RIE} ${JAVA_BINARY_LOCATION} -jar ./HelloWorld-1.0.jar helloworld.App"
-      - sleep 2
-      - >
-        docker run \
-          --name "${OS_DISTRIBUTION}-tester" \
-          --env "TARGET=${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c 'curl -X POST "http://${TARGET}:8080/2015-03-31/functions/function/invocations" -d "{}" --max-time 10'
-      - actual="$(docker logs --tail 1 "${OS_DISTRIBUTION}-tester" | xargs)"
-      - expected='success'
-      - |
-        echo "Response: ${actual}"
-        if [[ "$actual" != "$expected" ]]; then
-          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
-          exit -1
-        fi
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/run_invocation_test.sh
     finally:
       - |
         echo "---------Container Logs: ${OS_DISTRIBUTION}-app----------"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.1.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.1.yml
@@ -61,34 +61,7 @@ phases:
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:
     commands:
-      - set -x
-      - echo "Running Image ${IMAGE_TAG}"
-      - docker network create "${OS_DISTRIBUTION}-network"
-      - >
-        docker run \
-          --detach \
-          --name "${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c "/usr/bin/${RIE} ${JAVA_BINARY_LOCATION} -jar ./HelloWorld-1.0.jar helloworld.App"
-      - sleep 2
-      - >
-        docker run \
-          --name "${OS_DISTRIBUTION}-tester" \
-          --env "TARGET=${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c 'curl -X POST "http://${TARGET}:8080/2015-03-31/functions/function/invocations" -d "{}" --max-time 10'
-      - actual="$(docker logs --tail 1 "${OS_DISTRIBUTION}-tester" | xargs)"
-      - expected='success'
-      - |
-        echo "Response: ${actual}"
-        if [[ "$actual" != "$expected" ]]; then
-          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
-          exit -1
-        fi
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/run_invocation_test.sh
     finally:
       - |
         echo "---------Container Logs: ${OS_DISTRIBUTION}-app----------"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.2.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.2.yml
@@ -74,34 +74,7 @@ phases:
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:
     commands:
-      - set -x
-      - echo "Running Image ${IMAGE_TAG}"
-      - docker network create "${OS_DISTRIBUTION}-network"
-      - >
-        docker run \
-          --detach \
-          --name "${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c "/usr/bin/${RIE} ${JAVA_BINARY_LOCATION} -jar ./HelloWorld-1.0.jar helloworld.App"
-      - sleep 2
-      - >
-        docker run \
-          --name "${OS_DISTRIBUTION}-tester" \
-          --env "TARGET=${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c 'curl -X POST "http://${TARGET}:8080/2015-03-31/functions/function/invocations" -d "{}" --max-time 10'
-      - actual="$(docker logs --tail 1 "${OS_DISTRIBUTION}-tester" | xargs)"
-      - expected='success'
-      - |
-        echo "Response: ${actual}"
-        if [[ "$actual" != "$expected" ]]; then
-          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
-          exit -1
-        fi
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/run_invocation_test.sh
     finally:
       - |
         echo "---------Container Logs: ${OS_DISTRIBUTION}-app----------"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.centos.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.centos.yml
@@ -74,34 +74,7 @@ phases:
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:
     commands:
-      - set -x
-      - echo "Running Image ${IMAGE_TAG}"
-      - docker network create "${OS_DISTRIBUTION}-network"
-      - >
-        docker run \
-          --detach \
-          --name "${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c "/usr/bin/${RIE} ${JAVA_BINARY_LOCATION} -jar ./HelloWorld-1.0.jar helloworld.App"
-      - sleep 2
-      - >
-        docker run \
-          --name "${OS_DISTRIBUTION}-tester" \
-          --env "TARGET=${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c 'curl -X POST "http://${TARGET}:8080/2015-03-31/functions/function/invocations" -d "{}" --max-time 10'
-      - actual="$(docker logs --tail 1 "${OS_DISTRIBUTION}-tester" | xargs)"
-      - expected='success'
-      - |
-        echo "Response: ${actual}"
-        if [[ "$actual" != "$expected" ]]; then
-          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
-          exit -1
-        fi
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/run_invocation_test.sh
     finally:
       - |
         echo "---------Container Logs: ${OS_DISTRIBUTION}-app----------"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.debian.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.debian.yml
@@ -78,34 +78,7 @@ phases:
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:
     commands:
-      - set -x
-      - echo "Running Image ${IMAGE_TAG}"
-      - docker network create "${OS_DISTRIBUTION}-network"
-      - >
-        docker run \
-          --detach \
-          --name "${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c "/usr/bin/${RIE} ${JAVA_BINARY_LOCATION} -jar ./HelloWorld-1.0.jar helloworld.App"
-      - sleep 2
-      - >
-        docker run \
-          --name "${OS_DISTRIBUTION}-tester" \
-          --env "TARGET=${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c 'curl -X POST "http://${TARGET}:8080/2015-03-31/functions/function/invocations" -d "{}" --max-time 10'
-      - actual="$(docker logs --tail 1 "${OS_DISTRIBUTION}-tester" | xargs)"
-      - expected='success'
-      - |
-        echo "Response: ${actual}"
-        if [[ "$actual" != "$expected" ]]; then
-          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
-          exit -1
-        fi
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/run_invocation_test.sh
     finally:
       - |
         echo "---------Container Logs: ${OS_DISTRIBUTION}-app----------"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.ubuntu.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.ubuntu.yml
@@ -80,34 +80,7 @@ phases:
           --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
   build:
     commands:
-      - set -x
-      - echo "Running Image ${IMAGE_TAG}"
-      - docker network create "${OS_DISTRIBUTION}-network"
-      - >
-        docker run \
-          --detach \
-          --name "${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c "/usr/bin/${RIE} ${JAVA_BINARY_LOCATION} -jar ./HelloWorld-1.0.jar helloworld.App"
-      - sleep 2
-      - >
-        docker run \
-          --name "${OS_DISTRIBUTION}-tester" \
-          --env "TARGET=${OS_DISTRIBUTION}-app" \
-          --network "${OS_DISTRIBUTION}-network" \
-          --entrypoint="" \
-          "${IMAGE_TAG}" \
-          sh -c 'curl -X POST "http://${TARGET}:8080/2015-03-31/functions/function/invocations" -d "{}" --max-time 10'
-      - actual="$(docker logs --tail 1 "${OS_DISTRIBUTION}-tester" | xargs)"
-      - expected='success'
-      - |
-        echo "Response: ${actual}"
-        if [[ "$actual" != "$expected" ]]; then
-          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
-          exit -1
-        fi
+      - aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/run_invocation_test.sh
     finally:
       - |
         echo "---------Container Logs: ${OS_DISTRIBUTION}-app----------"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/run_invocation_test.sh
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/run_invocation_test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+set -euxo pipefail
+
+echo "Running Image ${IMAGE_TAG}"
+docker network create "${OS_DISTRIBUTION}-network"
+
+docker run \
+  --detach \
+  --name "${OS_DISTRIBUTION}-app" \
+  --network "${OS_DISTRIBUTION}-network" \
+  --entrypoint="" \
+  --platform="${PLATFORM}" \
+  "${IMAGE_TAG}" \
+  sh -c "/usr/bin/${RIE} ${JAVA_BINARY_LOCATION} -jar ./HelloWorld-1.0.jar helloworld.App"
+sleep 2
+
+# running on arm64 hosts with x86_64 being emulated takes significantly more time than any other combination
+if [[ "$(arch)" == "aarch64" ]] && [[ "${PLATFORM}" == "linux/amd64" ]]; then
+  declare -i time_out=150
+else
+  declare -i time_out=10
+fi
+
+docker run \
+  --name "${OS_DISTRIBUTION}-tester" \
+  --env "TARGET=${OS_DISTRIBUTION}-app" \
+  --env "MAX_TIME=${time_out}" \
+  --network "${OS_DISTRIBUTION}-network" \
+  --entrypoint="" \
+  --platform="${PLATFORM}" \
+    "${IMAGE_TAG}" \
+  sh -c 'curl -X POST "http://${TARGET}:8080/2015-03-31/functions/function/invocations" -d "{}" --max-time ${MAX_TIME}'
+actual="$(docker logs --tail 1 "${OS_DISTRIBUTION}-tester" | xargs)"
+expected='success'
+echo "Response: ${actual}"
+if [[ "${actual}" != "${expected}" ]]; then
+  echo "fail! runtime: ${RUNTIME} - expected output ${expected} - got ${actual}"
+  exit 1
+fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix os compatibility tests on arm64 host local builds:
* update `codebuild_build.sh` script from upstream to be able to set `local_agent_image`
* use `arm64` specific local agent image when running on `arm64` host
* extract invocation test logic to a separate script
* increase invocation timeout when running test on `arm64` with `x86_64` being emulated (this combination timed out with previous 10 sec configuration)
* set platform explicitly when running test images to avoid architecture discrepancy warning message

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
