### PR TITLE
Adding JSONAssert to ease debugging of event serialisation.

### DIFF
--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -65,6 +65,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.5.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>

--- a/aws-lambda-java-events/src/test/java/com/amazonaws/services/lambda/runtime/events/LambdaEventSerializersTest.java
+++ b/aws-lambda-java-events/src/test/java/com/amazonaws/services/lambda/runtime/events/LambdaEventSerializersTest.java
@@ -22,20 +22,20 @@ import com.amazonaws.services.lambda.runtime.events.s3.S3BatchEvent;
 import com.amazonaws.services.lambda.runtime.events.s3.S3BatchResponse;
 import com.amazonaws.services.lambda.runtime.events.s3.S3Event;
 import com.amazonaws.services.lambda.runtime.events.s3.S3ObjectLambdaEvent;
-import com.amazonaws.services.lambda.serialization.JacksonPojoSerializer;
 import com.amazonaws.services.lambda.serialization.CustomPojoSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ServiceLoader;
 
-import org.junit.jupiter.api.Assertions;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import static org.skyscreamer.jsonassert.JSONCompareMode.STRICT;
 
 public class LambdaEventSerializersTest {
 
-    private static final ObjectMapper OBJECT_MAPPER = JacksonPojoSerializer.getInstance().getMapper();
     private static final CustomPojoSerializer CUSTOM_POJO_SERIALIZER = loadSerializer();
 
     static public CustomPojoSerializer loadSerializer() {
@@ -45,483 +45,483 @@ public class LambdaEventSerializersTest {
     }
 
     @Test
-    public void testActiveMQEvent() throws IOException {
+    public void testActiveMQEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("active_mq_event.json");
         String actual = deserializeSerializeJsonToString(expected, ActiveMQEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testAPIGatewayCustomAuthorizerEvent() throws IOException {
+    public void testAPIGatewayCustomAuthorizerEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("api_gateway_custom_authorizer_event.json");
         String actual = deserializeSerializeJsonToString(expected, APIGatewayCustomAuthorizerEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testAPIGatewayProxyRequestEvent() throws IOException {
+    public void testAPIGatewayProxyRequestEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("api_gateway_proxy_request_event.json");
         String actual = deserializeSerializeJsonToString(expected, APIGatewayProxyRequestEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testAPIGatewayProxyResponseEvent() throws IOException {
+    public void testAPIGatewayProxyResponseEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("api_gateway_proxy_response_event.json");
         String actual = deserializeSerializeJsonToString(expected, APIGatewayProxyResponseEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testAPIGatewayV2CustomAuthorizerEvent() throws IOException {
+    public void testAPIGatewayV2CustomAuthorizerEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("api_gateway_v2_custom_authorizer_event.json");
         String actual = deserializeSerializeJsonToString(expected, APIGatewayV2CustomAuthorizerEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testAPIGatewayV2HTTPEvent() throws IOException {
+    public void testAPIGatewayV2HTTPEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("api_gateway_v2_http_event.json");
         String actual = deserializeSerializeJsonToString(expected, APIGatewayV2HTTPEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testAPIGatewayV2HTTPResponse() throws IOException {
+    public void testAPIGatewayV2HTTPResponse() throws IOException, JSONException {
         String expected = EventUtils.readEvent("api_gateway_v2_http_response.json");
         String actual = deserializeSerializeJsonToString(expected, APIGatewayV2HTTPResponse.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testAPIGatewayV2WebSocketEvent() throws IOException {
+    public void testAPIGatewayV2WebSocketEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("api_gateway_v2_web_socket_event.json");
         String actual = deserializeSerializeJsonToString(expected, APIGatewayV2WebSocketEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
         @Test
-    public void testAPIGatewayV2WebSocketResponse() throws IOException {
+    public void testAPIGatewayV2WebSocketResponse() throws IOException, JSONException {
         String expected = EventUtils.readEvent("api_gateway_v2_web_socket_response.json");
         String actual = deserializeSerializeJsonToString(expected, APIGatewayV2WebSocketResponse.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testApplicationLoadBalancerRequestEvent() throws IOException {
+    public void testApplicationLoadBalancerRequestEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("application_load_balancer_request_event.json");
         String actual = deserializeSerializeJsonToString(expected, ApplicationLoadBalancerRequestEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testApplicationLoadBalancerResponseEvent() throws IOException {
+    public void testApplicationLoadBalancerResponseEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("application_load_balancer_response_event.json");
         String actual = deserializeSerializeJsonToString(expected, ApplicationLoadBalancerResponseEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testAppSyncLambdaAuthorizerEvent() throws IOException {
+    public void testAppSyncLambdaAuthorizerEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("app_sync_lambda_authorizer_event.json");
         String actual = deserializeSerializeJsonToString(expected, AppSyncLambdaAuthorizerEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testAppSyncLambdaAuthorizerResponse() throws IOException {
+    public void testAppSyncLambdaAuthorizerResponse() throws IOException, JSONException {
         String expected = EventUtils.readEvent("app_sync_lambda_authorizer_response.json");
         String actual = deserializeSerializeJsonToString(expected, AppSyncLambdaAuthorizerResponse.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCloudFormationCustomResourceEvent() throws IOException {
+    public void testCloudFormationCustomResourceEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cloud_formation_custom_resource_event.json");
         String actual = deserializeSerializeJsonToString(expected, CloudFormationCustomResourceEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCloudFrontEvent() throws IOException {
+    public void testCloudFrontEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cloud_front_event.json");
         String actual = deserializeSerializeJsonToString(expected, CloudFrontEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCloudWatchLogsEvent() throws IOException {
+    public void testCloudWatchLogsEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cloud_watch_logs_event.json");
         String actual = deserializeSerializeJsonToString(expected, CloudWatchLogsEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCodeCommitEvent() throws IOException {
+    public void testCodeCommitEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("code_commit_event.json");
         String actual = deserializeSerializeJsonToString(expected, CodeCommitEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCognitoEvent() throws IOException {
+    public void testCognitoEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cognito_event.json");
         String actual = deserializeSerializeJsonToString(expected, CognitoEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCognitoUserPoolCreateAuthChallengeEvent() throws IOException {
+    public void testCognitoUserPoolCreateAuthChallengeEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cognito_user_pool_create_auth_challenge_event.json");
         String actual = deserializeSerializeJsonToString(expected, CognitoUserPoolCreateAuthChallengeEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCognitoUserPoolCustomMessageEvent() throws IOException {
+    public void testCognitoUserPoolCustomMessageEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cognito_user_pool_custom_message_event.json");
         String actual = deserializeSerializeJsonToString(expected, CognitoUserPoolCustomMessageEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCognitoUserPoolDefineAuthChallengeEvent() throws IOException {
+    public void testCognitoUserPoolDefineAuthChallengeEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cognito_user_pool_define_auth_challenge_event.json");
         String actual = deserializeSerializeJsonToString(expected, CognitoUserPoolDefineAuthChallengeEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCognitoUserPoolMigrateUserEvent() throws IOException {
+    public void testCognitoUserPoolMigrateUserEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cognito_user_pool_migrate_user_event.json");
         String actual = deserializeSerializeJsonToString(expected, CognitoUserPoolMigrateUserEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCognitoUserPoolPostAuthenticationEvent() throws IOException {
+    public void testCognitoUserPoolPostAuthenticationEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cognito_user_pool_post_authentication_event.json");
         String actual = deserializeSerializeJsonToString(expected, CognitoUserPoolPostAuthenticationEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCognitoUserPoolPostConfirmationEvent() throws IOException {
+    public void testCognitoUserPoolPostConfirmationEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cognito_user_pool_post_confirmation_event.json");
         String actual = deserializeSerializeJsonToString(expected, CognitoUserPoolPostConfirmationEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCognitoUserPoolPreAuthenticationEvent() throws IOException {
+    public void testCognitoUserPoolPreAuthenticationEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cognito_user_pool_pre_authentication_event.json");
         String actual = deserializeSerializeJsonToString(expected, CognitoUserPoolPreAuthenticationEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCognitoUserPoolPreSignUpEvent() throws IOException {
+    public void testCognitoUserPoolPreSignUpEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cognito_user_pool_pre_sign_up_event.json");
         String actual = deserializeSerializeJsonToString(expected, CognitoUserPoolPreSignUpEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCognitoUserPoolPreTokenGenerationEvent() throws IOException {
+    public void testCognitoUserPoolPreTokenGenerationEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cognito_user_pool_pre_token_generation_event.json");
         String actual = deserializeSerializeJsonToString(expected, CognitoUserPoolPreTokenGenerationEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testCognitoUserPoolVerifyAuthChallengeResponseEvent() throws IOException {
+    public void testCognitoUserPoolVerifyAuthChallengeResponseEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("cognito_user_pool_verify_auth_challenge_response_event.json");
         String actual = deserializeSerializeJsonToString(expected, CognitoUserPoolVerifyAuthChallengeResponseEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testConfigEvent() throws IOException {
+    public void testConfigEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("config_event.json");
         String actual = deserializeSerializeJsonToString(expected, ConfigEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testConnectEvent() throws IOException {
+    public void testConnectEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("connect_event.json");
         String actual = deserializeSerializeJsonToString(expected, ConnectEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testDynamodbEvent() throws IOException {
+    public void testDynamodbEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("dynamodb_event.json");
         String actual = deserializeSerializeJsonToString(expected, DynamodbEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testDynamodbTimeWindowEvent() throws IOException {
+    public void testDynamodbTimeWindowEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("dynamodb_time_window_event.json");
         String actual = deserializeSerializeJsonToString(expected, DynamodbTimeWindowEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testEventBridgeEvent() throws IOException {
+    public void testEventBridgeEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("eventbridge_event.json");
         String actual = deserializeSerializeJsonToString(expected, EventBridgeEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testIamPolicyResponse() throws IOException {
+    public void testIamPolicyResponse() throws IOException, JSONException {
         String expected = EventUtils.readEvent("iam_policy_response.json");
         String actual = deserializeSerializeJsonToString(expected, IamPolicyResponse.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testIamPolicyResponseV1() throws IOException {
+    public void testIamPolicyResponseV1() throws IOException, JSONException {
         String expected = EventUtils.readEvent("iam_policy_response_v1.json");
         String actual = deserializeSerializeJsonToString(expected, IamPolicyResponseV1.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testIoTButtonEvent() throws IOException {
+    public void testIoTButtonEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("iot_button_event.json");
         String actual = deserializeSerializeJsonToString(expected, IoTButtonEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testKafkaEvent() throws IOException {
+    public void testKafkaEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("kafka_event.json");
         String actual = deserializeSerializeJsonToString(expected, KafkaEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testKinesisAnalyticsFirehoseInputPreprocessingEvent() throws IOException {
+    public void testKinesisAnalyticsFirehoseInputPreprocessingEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("kinesis_analytics_firehose_input_preprocessing_event.json");
         String actual = deserializeSerializeJsonToString(expected, KinesisAnalyticsFirehoseInputPreprocessingEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testKinesisAnalyticsInputPreprocessingResponse() throws IOException {
+    public void testKinesisAnalyticsInputPreprocessingResponse() throws IOException, JSONException {
         String expected = EventUtils.readEvent("kinesis_analytics_input_preprocessing_response_event.json");
         String actual = deserializeSerializeJsonToString(expected, KinesisAnalyticsInputPreprocessingResponse.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testKinesisAnalyticsOutputDeliveryEvent() throws IOException {
+    public void testKinesisAnalyticsOutputDeliveryEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("kinesis_analytics_output_delivery_event.json");
         String actual = deserializeSerializeJsonToString(expected, KinesisAnalyticsOutputDeliveryEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testKinesisAnalyticsOutputDeliveryResponse() throws IOException {
+    public void testKinesisAnalyticsOutputDeliveryResponse() throws IOException, JSONException {
         String expected = EventUtils.readEvent("kinesis_analytics_output_delivery_response_event.json");
         String actual = deserializeSerializeJsonToString(expected, KinesisAnalyticsOutputDeliveryResponse.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testKinesisAnalyticsStreamsInputPreprocessingEvent() throws IOException {
+    public void testKinesisAnalyticsStreamsInputPreprocessingEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("kinesis_analytics_streams_input_preprocessing_event.json");
         String actual = deserializeSerializeJsonToString(expected, KinesisAnalyticsStreamsInputPreprocessingEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testKinesisEvent() throws IOException {
+    public void testKinesisEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("kinesis_event.json");
         String actual = deserializeSerializeJsonToString(expected, KinesisEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testKinesisFirehoseEvent() throws IOException {
+    public void testKinesisFirehoseEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("kinesis_firehose_event.json");
         String actual = deserializeSerializeJsonToString(expected, KinesisFirehoseEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testKinesisTimeWindowEvent() throws IOException {
+    public void testKinesisTimeWindowEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("kinesis_time_window_event.json");
         String actual = deserializeSerializeJsonToString(expected, KinesisTimeWindowEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testLambdaDestinationEvent() throws IOException {
+    public void testLambdaDestinationEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("lambda_destination_event.json");
         String actual = deserializeSerializeJsonToString(expected, LambdaDestinationEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testLexEvent() throws IOException {
+    public void testLexEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("lex_event.json");
         String actual = deserializeSerializeJsonToString(expected, LexEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testRabbitMQ() throws IOException {
+    public void testRabbitMQ() throws IOException, JSONException {
         String expected = EventUtils.readEvent("rabbit_mq.json");
         String actual = deserializeSerializeJsonToString(expected, RabbitMQEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testS3BatchEvent() throws IOException {
+    public void testS3BatchEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("s3_batch_event.json");
         String actual = deserializeSerializeJsonToString(expected, S3BatchEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testS3BatchResponse() throws IOException {
+    public void testS3BatchResponse() throws IOException, JSONException {
         String expected = EventUtils.readEvent("s3_batch_response.json");
         String actual = deserializeSerializeJsonToString(expected, S3BatchResponse.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testS3Event() throws IOException {
+    public void testS3Event() throws IOException, JSONException {
         String expected = EventUtils.readEvent("s3_event.json");
         String actual = deserializeSerializeJsonToString(expected, S3Event.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testS3ObjectLambdaEvent() throws IOException {
+    public void testS3ObjectLambdaEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("s3_object_lambda_event.json");
         String actual = deserializeSerializeJsonToString(expected, S3ObjectLambdaEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testScheduledEvent() throws IOException {
+    public void testScheduledEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("scheduled_event.json");
         String actual = deserializeSerializeJsonToString(expected, ScheduledEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testSecretsManagerRotationEvent() throws IOException {
+    public void testSecretsManagerRotationEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("secrets_manager_rotation_event.json");
         String actual = deserializeSerializeJsonToString(expected, SecretsManagerRotationEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testSimpleIAMPolicyResponse() throws IOException {
+    public void testSimpleIAMPolicyResponse() throws IOException, JSONException {
         String expected = EventUtils.readEvent("simple_iam_policy_response.json");
         String actual = deserializeSerializeJsonToString(expected, SimpleIAMPolicyResponse.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testSNSEvent() throws IOException {
+    public void testSNSEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("sns_event.json");
         String actual = deserializeSerializeJsonToString(expected, SNSEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testSQSBatchResponse() throws IOException {
+    public void testSQSBatchResponse() throws IOException, JSONException {
         String expected = EventUtils.readEvent("sqs_batch_response.json");
         String actual = deserializeSerializeJsonToString(expected, SQSBatchResponse.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testSQSEvent() throws IOException {
+    public void testSQSEvent() throws IOException, JSONException {
         String expected = EventUtils.readEvent("sqs_event.json");
         String actual = deserializeSerializeJsonToString(expected, SQSEvent.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testStreamsEventResponse() throws IOException {
+    public void testStreamsEventResponse() throws IOException, JSONException {
         String expected = EventUtils.readEvent("streams_event_response.json");
         String actual = deserializeSerializeJsonToString(expected, StreamsEventResponse.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     @Test
-    public void testTimeWindowEventResponse() throws IOException {
+    public void testTimeWindowEventResponse() throws IOException, JSONException {
         String expected = EventUtils.readEvent("time_window_event_response.json");
         String actual = deserializeSerializeJsonToString(expected, TimeWindowEventResponse.class);
 
-        assertJsonEqual(expected, actual);
+        assertEquals(expected, actual, STRICT);
     }
 
     private <T> String deserializeSerializeJsonToString(String expected, Class<T> modelClass) {
@@ -531,9 +531,4 @@ public class LambdaEventSerializersTest {
         CUSTOM_POJO_SERIALIZER.toJson(event, baos, modelClass);
         return EventUtils.bytesToString(baos.toByteArray());
     }
-
-    private void assertJsonEqual(String expected, String actual) throws IOException {
-        Assertions.assertEquals(OBJECT_MAPPER.readTree(expected), OBJECT_MAPPER.readTree(actual));
-    }
-
 }


### PR DESCRIPTION
*Issue #, if available:*
None 

*Description of changes:*
During debugging of https://github.com/aws/aws-lambda-java-libs/pull/321#issuecomment-1140231679 it was made much easier by the descriptive error messages given by JSONAssert.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
