### PR TITLE
Optimize jar discovery

### DIFF
--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoader.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoader.java
@@ -3,6 +3,7 @@
 package com.amazonaws.services.lambda.runtime.api.client;
 
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -18,6 +19,18 @@ class CustomerClassLoader extends URLClassLoader {
      * does not depend on the underlying filesystem.
      */
     private final static Comparator<String> LEXICAL_SORT_ORDER = Comparator.comparing(String::toString);
+    private final static FilenameFilter JAR_FILE_NAME_FILTER = new FilenameFilter() {
+
+        @Override
+        public boolean accept(File dir, String name) {
+            int offset = name.length() - 4;
+            if (offset <= 0) { /* must be at least A.jar */
+                return false;
+            } else {
+                return name.startsWith(".jar", offset);
+            }
+        }
+    };
 
     CustomerClassLoader(String taskRoot, String optRoot, ClassLoader parent) throws IOException {
         super(getUrls(taskRoot, optRoot), parent);
@@ -36,22 +49,10 @@ class CustomerClassLoader extends URLClassLoader {
         if (!dir.isDirectory()) {
             return;
         }
-        String[] names = dir.list();
+        String[] names = dir.list(JAR_FILE_NAME_FILTER);
         if (names == null) {
             return;
         }
-        List<String> nameList = new ArrayList<>();
-        for (String path : names) {
-            if (path.endsWith(".jar")) {
-                nameList.add(path);
-            }
-        }
-
-        if (nameList.isEmpty()) {
-            return;
-        }
-
-        names = nameList.toArray(new String[nameList.size()]);
         Arrays.sort(names, CustomerClassLoader.LEXICAL_SORT_ORDER);
 
         for (String path : names) {

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoader.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoader.java
@@ -46,6 +46,11 @@ class CustomerClassLoader extends URLClassLoader {
                 nameList.add(path);
             }
         }
+
+        if (nameList.isEmpty()) {
+            return;
+        }
+
         names = nameList.toArray(new String[nameList.size()]);
         Arrays.sort(names, CustomerClassLoader.LEXICAL_SORT_ORDER);
 

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoader.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoader.java
@@ -36,15 +36,14 @@ class CustomerClassLoader extends URLClassLoader {
         if (!dir.isDirectory()) {
             return;
         }
-        String[] names = dir.list();
+        String[] names = dir.list((directory, name) -> name.endsWith(".jar"));
         if (names == null) {
             return;
         }
         Arrays.sort(names, CustomerClassLoader.LEXICAL_SORT_ORDER);
-        for(String path : names) {
-            if(path.endsWith(".jar")) {
-                result.add(newURL(dir, path));
-            }
+
+        for (String path : names) {
+            result.add(newURL(dir, path));
         }
     }
 

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoader.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoader.java
@@ -36,10 +36,17 @@ class CustomerClassLoader extends URLClassLoader {
         if (!dir.isDirectory()) {
             return;
         }
-        String[] names = dir.list((directory, name) -> name.endsWith(".jar"));
+        String[] names = dir.list();
         if (names == null) {
             return;
         }
+        List<String> nameList = new ArrayList<>();
+        for (String path : names) {
+            if (path.endsWith(".jar")) {
+                nameList.add(path);
+            }
+        }
+        names = nameList.toArray(new String[nameList.size()]);
         Arrays.sort(names, CustomerClassLoader.LEXICAL_SORT_ORDER);
 
         for (String path : names) {

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoader.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/CustomerClassLoader.java
@@ -49,7 +49,7 @@ class CustomerClassLoader extends URLClassLoader {
         if (!dir.isDirectory()) {
             return;
         }
-        String[] names = dir.list(JAR_FILE_NAME_FILTER);
+        String[] names = dir.list(CustomerClassLoader.JAR_FILE_NAME_FILTER);
         if (names == null) {
             return;
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use a filename filter to only return found jar files. Sorting of the array will only then run on the jar files and not on all files.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
