### PR TITLE
#220 Fix case-sensitivity of HTTP headers in models

### DIFF
--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -77,6 +77,13 @@
       <version>${lombok.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.18.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ApplicationLoadBalancerRequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ApplicationLoadBalancerRequestEvent.java
@@ -63,8 +63,8 @@ public class ApplicationLoadBalancerRequestEvent implements Serializable  {
     private String path;
     private Map<String, String> queryStringParameters;
     private Map<String, List<String>> multiValueQueryStringParameters;
-    private Map<String, String> headers;
-    private Map<String, List<String>> multiValueHeaders;
+    private HttpHeaders<String> headers;
+    private HttpHeaders<List<String>> multiValueHeaders;
     private String body;
     @JsonProperty("isBase64Encoded")
     private boolean isBase64Encoded;

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ApplicationLoadBalancerResponseEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ApplicationLoadBalancerResponseEvent.java
@@ -42,8 +42,8 @@ public class ApplicationLoadBalancerResponseEvent implements Serializable {
     private String statusDescription;
     @JsonProperty("isBase64Encoded")
     private boolean isBase64Encoded;
-    private Map<String, String> headers;
-    private Map<String, List<String>> multiValueHeaders;
+    private HttpHeaders<String> headers;
+    private HttpHeaders<List<String>> multiValueHeaders;
     private String body;
 
 }

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/HttpHeaders.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/HttpHeaders.java
@@ -1,0 +1,89 @@
+package com.amazonaws.services.lambda.runtime.events;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Class that represents Http Headers.
+ * <br>
+ * Http Headers are case-insensitive.
+ * Thus, requesting a header "host" will yield the same result as "Host" or "HOST"
+ */
+public class HttpHeaders<T> implements Map<String, T> {
+
+    // Headers are case insensitive (https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)
+    private final Map<String, T> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override
+    public T get(Object key) {
+        return map.get(key);
+    }
+
+    @Override
+    public T put(String key, T value) {
+        return map.put(key, value);
+    }
+
+    @Override
+    public T remove(Object key) {
+        return map.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends T> m) {
+        map.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return map.keySet();
+    }
+
+    @Override
+    public Collection<T> values() {
+        return map.values();
+    }
+
+    @Override
+    public Set<Entry<String, T>> entrySet() {
+        return map.entrySet();
+    }
+
+    public static <T> HttpHeaders<T> mergeOrReplace(Map<String, T> from) {
+        if (from == null) return null;
+        if (from instanceof HttpHeaders) return (HttpHeaders<T>) from;
+
+        HttpHeaders<T> out = new HttpHeaders<>();
+        if (from.isEmpty()) return out;
+
+        out.putAll(from);
+        return out;
+    }
+}

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayCustomAuthorizerEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayCustomAuthorizerEvent.java
@@ -13,6 +13,7 @@
 
 package com.amazonaws.services.lambda.runtime.events.apigateway;
 
+import com.amazonaws.services.lambda.runtime.events.HttpHeaders;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -39,7 +40,7 @@ public class APIGatewayCustomAuthorizerEvent {
     private String resource;
     private String path;
     private String httpMethod;
-    private Map<String, String> headers;
+    private HttpHeaders<String> headers;
     private Map<String, String> queryStringParameters;
     private Map<String, String> pathParameters;
     private Map<String, String> stageVariables;

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayProxyRequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayProxyRequestEvent.java
@@ -13,6 +13,7 @@
 
 package com.amazonaws.services.lambda.runtime.events.apigateway;
 
+import com.amazonaws.services.lambda.runtime.events.HttpHeaders;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -40,9 +41,9 @@ public class APIGatewayProxyRequestEvent implements Serializable {
 
     private String httpMethod;
 
-    private Map<String, String> headers;
+    private HttpHeaders<String> headers;
 
-    private Map<String, List<String>> multiValueHeaders;
+    private HttpHeaders<List<String>> multiValueHeaders;
 
     private Map<String, String> queryStringParameters;
 

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayProxyResponseEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayProxyResponseEvent.java
@@ -13,6 +13,7 @@
 
 package com.amazonaws.services.lambda.runtime.events.apigateway;
 
+import com.amazonaws.services.lambda.runtime.events.HttpHeaders;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -35,7 +36,7 @@ public class APIGatewayProxyResponseEvent implements Serializable {
     
     private Integer statusCode;
 
-    private Map<String, String> headers;
+    private HttpHeaders<String> headers;
     
     private String body;
 

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayV2CustomAuthorizerEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayV2CustomAuthorizerEvent.java
@@ -13,6 +13,7 @@
 
 package com.amazonaws.services.lambda.runtime.events.apigateway;
 
+import com.amazonaws.services.lambda.runtime.events.HttpHeaders;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -43,7 +44,7 @@ public class APIGatewayV2CustomAuthorizerEvent {
     private String rawPath;
     private String rawQueryString;
     private List<String> cookies;
-    private Map<String, String> headers;
+    private HttpHeaders<String> headers;
     private Map<String, String> queryStringParameters;
     private RequestContext requestContext;
     private Map<String, String> pathParameters;

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayV2HTTPEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayV2HTTPEvent.java
@@ -13,6 +13,7 @@
 
 package com.amazonaws.services.lambda.runtime.events.apigateway;
 
+import com.amazonaws.services.lambda.runtime.events.HttpHeaders;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -38,7 +39,7 @@ public class APIGatewayV2HTTPEvent {
     private String rawPath;
     private String rawQueryString;
     private List<String> cookies;
-    private Map<String, String> headers;
+    private HttpHeaders<String> headers;
     private Map<String, String> queryStringParameters;
     private Map<String, String> pathParameters;
     private Map<String, String> stageVariables;
@@ -46,6 +47,10 @@ public class APIGatewayV2HTTPEvent {
     @JsonProperty("isBase64Encoded")
     private boolean isBase64Encoded;
     private RequestContext requestContext;
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = HttpHeaders.mergeOrReplace(headers);
+    }
 
     @AllArgsConstructor
     @Builder(setterPrefix = "with")

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayV2HTTPResponse.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayV2HTTPResponse.java
@@ -13,6 +13,7 @@
 
 package com.amazonaws.services.lambda.runtime.events.apigateway;
 
+import com.amazonaws.services.lambda.runtime.events.HttpHeaders;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -29,10 +30,29 @@ import java.util.Map;
 @NoArgsConstructor
 public class APIGatewayV2HTTPResponse {
     private int statusCode;
-    private Map<String, String> headers;
-    private Map<String, List<String>> multiValueHeaders;
+    private HttpHeaders<String> headers;
+    private HttpHeaders<List<String>> multiValueHeaders;
     private List<String> cookies;
     private String body;
     @JsonProperty("isBase64Encoded")
     private boolean isBase64Encoded;
+
+    public static APIGatewayV2HTTPResponseBuilder builder() {
+        return new APIGatewayV2HTTPResponseBuilder();
+    }
+
+    public static class APIGatewayV2HTTPResponseBuilder {
+        private HttpHeaders<String> headers;
+        private HttpHeaders<List<String>> multiValueHeaders;
+
+        public APIGatewayV2HTTPResponseBuilder withHeaders(Map<String, String> headers) {
+            this.headers = HttpHeaders.mergeOrReplace(headers);
+            return this;
+        }
+
+        public APIGatewayV2HTTPResponseBuilder withMultiValueHeaders(Map<String, List<String>> multiValueHeaders) {
+            this.multiValueHeaders = HttpHeaders.mergeOrReplace(multiValueHeaders);
+            return this;
+        }
+    }
 }

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayV2WebSocketEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayV2WebSocketEvent.java
@@ -13,6 +13,7 @@
 
 package com.amazonaws.services.lambda.runtime.events.apigateway;
 
+import com.amazonaws.services.lambda.runtime.events.HttpHeaders;
 import lombok.Data;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -95,8 +96,8 @@ public class APIGatewayV2WebSocketEvent implements Serializable {
     private String resource;
     private String path;
     private String httpMethod;
-    private Map<String, String> headers;
-    private Map<String, List<String>> multiValueHeaders;
+    private HttpHeaders<String> headers;
+    private HttpHeaders<List<String>> multiValueHeaders;
     private Map<String, String> queryStringParameters;
     private Map<String, List<String>> multiValueQueryStringParameters;
     private Map<String, String> pathParameters;

--- a/aws-lambda-java-events/src/test/java/com/amazonaws/services/lambda/runtime/events/HttpHeadersTest.java
+++ b/aws-lambda-java-events/src/test/java/com/amazonaws/services/lambda/runtime/events/HttpHeadersTest.java
@@ -1,0 +1,148 @@
+package com.amazonaws.services.lambda.runtime.events;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpHeadersTest {
+
+    @Test
+    public void testHttpHeadersCanBeInit() {
+        HttpHeaders<String> obj = new HttpHeaders<>();
+    }
+
+    @Test
+    public void testValueCanBeAddedToHttpHeaders() {
+        HttpHeaders<String> obj = new HttpHeaders<>();
+        obj.put("key", "value");
+        assertThat(obj).hasSize(1);
+        assertThat(obj).containsEntry("key", "value");
+    }
+
+    @Test
+    public void testValuesCanBeAddedToHttpHeaders() {
+        HttpHeaders<String> obj = new HttpHeaders<>();
+        obj.put("key", "value");
+        obj.put("key2", "value2");
+        obj.put("key3", "value3");
+
+        assertThat(obj).hasSize(3);
+        assertThat(obj).containsEntry("key", "value");
+        assertThat(obj).containsEntry("key2", "value2");
+        assertThat(obj).containsEntry("key3", "value3");
+    }
+
+    @Test
+    public void testOverridingHttpHeadersKeysIsCaseInsensitive() {
+        HttpHeaders<String> obj = new HttpHeaders<>();
+        obj.put("key", "value");
+        obj.put("KEY", "value2");
+        obj.put("kEy", "value3");
+
+        assertThat(obj).hasSize(1);
+        assertThat(obj).containsEntry("key", "value3");
+    }
+
+    @Test
+    public void testValuesCanBeRemovedFromHttpHeaders() {
+        HttpHeaders<String> obj = new HttpHeaders<>();
+        obj.put("key", "value");
+
+        assertThat(obj).hasSize(1);
+        obj.remove("key");
+        assertThat(obj).isEmpty();
+    }
+
+    @Test
+    public void testContainedKeysAreContainedInHttpHeaders() {
+        HttpHeaders<String> obj = new HttpHeaders<>();
+        obj.put("key", "value");
+
+        assertTrue(obj.containsKey("key"));
+    }
+
+    @Test
+    public void testContainedValuesAreContainedInHttpHeaders() {
+        HttpHeaders<String> obj = new HttpHeaders<>();
+        obj.put("key", "value");
+
+        assertTrue(obj.containsValue("value"));
+    }
+
+    @Test
+    public void testPutAllWorksInHttpHeaders() {
+        HttpHeaders<String> obj = new HttpHeaders<>();
+        obj.put("key", "value");
+        obj.put("key2", "value2");
+
+        Map<String, String> otherMap = new HashMap<>();
+        otherMap.put("otherKey1", "otherVal1");
+        otherMap.put("otherKey2", "otherVal2");
+        otherMap.put("otherKey3", "otherVal3");
+
+        obj.putAll(otherMap);
+
+        assertThat(obj).hasSize(5);
+        assertThat(obj).containsEntry("key", "value");
+        assertThat(obj).containsEntry("key2", "value2");
+        assertThat(obj).containsEntry("otherKey1", "otherVal1");
+        assertThat(obj).containsEntry("otherKey2", "otherVal2");
+        assertThat(obj).containsEntry("otherKey3", "otherVal3");
+    }
+
+    @Test
+    public void testClearWorksInHttpHeaders() {
+        HttpHeaders<String> obj = new HttpHeaders<>();
+        obj.put("key", "value");
+        obj.put("key2", "value2");
+
+        assertThat(obj).hasSize(2);
+
+        obj.clear();
+
+        assertThat(obj).hasSize(0);
+    }
+
+    @Test
+    public void testKeySetWorksInHttpHeaders() {
+        HttpHeaders<String> obj = new HttpHeaders<>();
+        obj.put("key", "value");
+        obj.put("key2", "value2");
+
+        Set<String> keySet = obj.keySet();
+
+        assertNotNull(keySet);
+        assertThat(keySet).hasSize(2);
+        assertThat(keySet).contains("key", "key2");
+    }
+
+    @Test
+    public void testValuesWorksInHttpHeaders() {
+        HttpHeaders<String> obj = new HttpHeaders<>();
+        obj.put("key", "value");
+        obj.put("key2", "value2");
+
+        Collection<String> values = obj.values();
+
+        assertNotNull(values);
+        assertThat(values).hasSize(2);
+        assertThat(values).contains("value", "value2");
+    }
+
+    @Test
+    public void testEntrySetWorksInHttpHeaders() {
+        HttpHeaders<String> obj = new HttpHeaders<>();
+        obj.put("key", "value");
+        obj.put("key2", "value2");
+
+        Set<Map.Entry<String, String>> entrySet = obj.entrySet();
+
+        assertNotNull(entrySet);
+        assertThat(entrySet).hasSize(2);
+        assertThat(entrySet).contains(new AbstractMap.SimpleEntry<>("key", "value"));
+        assertThat(entrySet).contains(new AbstractMap.SimpleEntry<>("key2", "value2"));
+    }
+}

--- a/aws-lambda-java-events/src/test/java/com/amazonaws/services/lambda/runtime/events/HttpHeadersUtilTest.java
+++ b/aws-lambda-java-events/src/test/java/com/amazonaws/services/lambda/runtime/events/HttpHeadersUtilTest.java
@@ -1,0 +1,146 @@
+package com.amazonaws.services.lambda.runtime.events;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HttpHeadersUtilTest {
+
+    @Test
+    public void testWhenFromObjNullThenNullReturned() {
+        Map<String, String> result = HttpHeaders.mergeOrReplace(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testWhenFromObjEmptyThenEmptyHttpHeadersReturned() {
+        Map<String, String> from = new HashMap<>();
+        Map<String, String> result = HttpHeaders.mergeOrReplace(from);
+
+        assertNotNull(result);
+        assertInstanceOf(HttpHeaders.class, result);
+        assertEquals(Collections.emptyMap(), result);
+    }
+
+    @Test
+    public void testWhenFromObjIsHashmapThenNewHttpHeadersReturned() {
+        HashMap<String, String> from = createHashMap("key", "value");
+        Map<String, String> result = HttpHeaders.mergeOrReplace(from);
+
+        assertNotNull(result);
+        assertInstanceOf(HttpHeaders.class, result);
+        assertEquals(from, result);
+    }
+
+    @Test
+    public void testWhenFromObjIsHashmapMultiValueThenNewHttpHeadersReturned() {
+        HashMap<String, String> from = createHashMap(
+                "key", "value",
+                "key2", "value2",
+                "key3", "value3"
+        );
+        Map<String, String> result = HttpHeaders.mergeOrReplace(from);
+
+        assertNotNull(result);
+        assertInstanceOf(HttpHeaders.class, result);
+        assertEquals(from, result);
+    }
+
+    @Test
+    public void testWhenFromObjIsTreemapMultiValueThenNewHttpHeadersReturned() {
+        TreeMap<String, String> from = createTreeMap(
+                "key", "value",
+                "key2", "value2",
+                "key3", "value3"
+        );
+        Map<String, String> result = HttpHeaders.mergeOrReplace(from);
+
+        assertNotNull(result);
+        assertInstanceOf(HttpHeaders.class, result);
+        assertEquals(from, result);
+    }
+
+    @Test
+    public void testWhenFromObjIsDuplicatedKeyMultiValueTreeMapThenReturnedHttpHeadersContainOnlyFinalValue() {
+        TreeMap<String, String> from = createTreeMap(
+                "key", "value",
+                "KEY", "value2",
+                "kEy", "value3",
+                Collections.reverseOrder()
+        );
+        Map<String, String> result = HttpHeaders.mergeOrReplace(from);
+
+        assertNotNull(result);
+        assertInstanceOf(HttpHeaders.class, result);
+        assertEquals(1, result.size());
+        Map.Entry<String, String> lastEntry = from.lastEntry();
+        assertEquals(result.getOrDefault(lastEntry.getKey(), null), lastEntry.getValue());
+    }
+
+    @Test
+    public void testWhenFromObjIsDuplicatedKeyMultiValueHashMapThenReturnedHttpHeadersContainOnlyOneValue() {
+        HashMap<String, String> from = createHashMap(
+                "key", "value",
+                "KEY", "value2",
+                "kEy", "value3"
+        );
+        Map<String, String> result = HttpHeaders.mergeOrReplace(from);
+
+        assertNotNull(result);
+        assertInstanceOf(HttpHeaders.class, result);
+        assertEquals(1, result.size());
+
+        Map.Entry<String, String> entry = from.entrySet().iterator().next();
+        assertTrue(from.entrySet().stream()
+                .anyMatch(e -> entry.getKey().equals(e.getKey()) && entry.getValue().equals(e.getValue())));
+    }
+
+    @Test
+    public void testWhenFromObjAlreadyHttpHeadersThenSameInstanceReturned() {
+        Map<String, String> from = new HttpHeaders<>();
+        from.put("key", "value");
+
+        Map<String, String> result = HttpHeaders.mergeOrReplace(from);
+        assertSame(from, result);
+    }
+
+    @Test
+    public void testWhenFromObjAlreadyEmptyHttpHeadersThenSameInstanceReturned() {
+        Map<String, String> from = new HttpHeaders<>();
+
+        Map<String, String> result = HttpHeaders.mergeOrReplace(from);
+        assertSame(from, result);
+    }
+
+    private static <T> HashMap<String, T> createHashMap(String key1, T val1) {
+        HashMap<String, T> map = new HashMap<>();
+        map.put(key1, val1);
+        return map;
+    }
+
+    private static <T> HashMap<String, T> createHashMap(String key1, T val1, String key2, T val2, String key3, T val3) {
+        HashMap<String, T> map = new HashMap<>();
+        map.put(key1, val1);
+        map.put(key2, val2);
+        map.put(key3, val3);
+        return map;
+    }
+
+    private static <T> TreeMap<String, T> createTreeMap(String key1, T val1, String key2, T val2, String key3, T val3) {
+        TreeMap<String, T> map = new TreeMap<>();
+        map.put(key1, val1);
+        map.put(key2, val2);
+        map.put(key3, val3);
+        return map;
+    }
+
+    private static <T> TreeMap<String, T> createTreeMap(String key1, T val1, String key2, T val2, String key3, T val3, java.util.Comparator<T> ordering) {
+        TreeMap<String, T> map = new TreeMap<>();
+        map.put(key1, val1);
+        map.put(key2, val2);
+        map.put(key3, val3);
+        return map;
+    }
+}

--- a/aws-lambda-java-tests/src/test/java/com/amazonaws/services/lambda/runtime/tests/HeadersTest.java
+++ b/aws-lambda-java-tests/src/test/java/com/amazonaws/services/lambda/runtime/tests/HeadersTest.java
@@ -1,0 +1,56 @@
+package com.amazonaws.services.lambda.runtime.tests;
+
+import com.amazonaws.services.lambda.runtime.events.ApplicationLoadBalancerRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.apigateway.APIGatewayCustomAuthorizerEvent;
+import com.amazonaws.services.lambda.runtime.events.apigateway.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.apigateway.APIGatewayV2CustomAuthorizerEvent;
+import com.amazonaws.services.lambda.runtime.events.apigateway.APIGatewayV2HTTPEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HeadersTest {
+
+    @Test
+    public void testHeadersApiGatewayRestEvent() {
+        APIGatewayProxyRequestEvent event = EventLoader.loadApiGatewayRestEvent("apigw_rest_event.json");
+
+        assertThat(event.getHeaders().get("Header1")).isEqualTo("value1");
+        assertThat(event.getHeaders().get("header1")).isEqualTo("value1");
+        assertThat(event.getMultiValueHeaders().get("header1")).contains("value1", "value11");
+        assertThat(event.getMultiValueHeaders().get("Header1")).contains("value1", "value11");
+        assertThat(event.getHeaders()).hasSize(2);
+    }
+
+    @Test
+    public void testHeadersApiGatewayHttpEvent() {
+        APIGatewayV2HTTPEvent event = EventLoader.loadApiGatewayHttpEvent("apigw_http_event.json");
+
+        assertThat(event.getHeaders().get("Header1")).isEqualTo("value1");
+        assertThat(event.getHeaders().get("header1")).isEqualTo("value1");
+    }
+
+    @Test
+    public void testHeadersAPIGatewayCustomAuthorizerEvent() {
+        APIGatewayCustomAuthorizerEvent event = EventLoader.loadAPIGatewayCustomAuthorizerEvent("apigw_auth.json");
+
+        assertThat(event.getHeaders().get("Accept")).isEqualTo("*/*");
+        assertThat(event.getHeaders().get("accept")).isEqualTo("*/*");
+    }
+
+    @Test
+    public void testHeadersAPIGatewayV2CustomAuthorizerEvent() {
+        APIGatewayV2CustomAuthorizerEvent event = EventLoader.loadAPIGatewayV2CustomAuthorizerEvent("apigw_auth_v2.json");
+
+        assertThat(event.getHeaders().get("Header1")).isEqualTo("Value1");
+        assertThat(event.getHeaders().get("header1")).isEqualTo("Value1");
+    }
+
+    @Test
+    public void testHeadersApplicationLoadBalancerRequestEvent() {
+        ApplicationLoadBalancerRequestEvent event = EventLoader.loadApplicationLoadBalancerRequestEvent("elb_event.json");
+
+        assertThat(event.getHeaders().get("Accept")).isEqualTo("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+        assertThat(event.getHeaders().get("accept")).isEqualTo("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+    }
+}

--- a/aws-lambda-java-tests/src/test/resources/apigw_auth_v2.json
+++ b/aws-lambda-java-tests/src/test/resources/apigw_auth_v2.json
@@ -8,8 +8,9 @@
   "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
   "cookies": [ "cookie1", "cookie2" ],
   "headers": {
-    "Header1": "value1",
-    "Header2": "value2"
+    "header1": "value1",
+    "Header2": "value2",
+    "Header1": "Value1"
   },
   "queryStringParameters": { "parameter1": "value1,value2", "parameter2": "value" },
   "requestContext": {

--- a/aws-lambda-java-tests/src/test/resources/apigw_http_event.json
+++ b/aws-lambda-java-tests/src/test/resources/apigw_http_event.json
@@ -8,8 +8,9 @@
     "cookie2"
   ],
   "headers": {
-    "Header1": "value1",
-    "Header2": "value1,value2"
+    "Header1": "Value1",
+    "Header2": "value1,value2",
+    "header1": "value1"
   },
   "queryStringParameters": {
     "parameter1": "value1,value2",

--- a/aws-lambda-java-tests/src/test/resources/apigw_rest_event.json
+++ b/aws-lambda-java-tests/src/test/resources/apigw_rest_event.json
@@ -4,8 +4,9 @@
   "path": "/my/path",
   "httpMethod": "GET",
   "headers": {
-    "Header1": "value1",
-    "Header2": "value2"
+    "Header1": "Value1",
+    "Header2": "value2",
+    "header1": "value1"
   },
   "multiValueHeaders": {
     "Header1": [
@@ -14,6 +15,10 @@
     "Header2": [
       "value1",
       "value2"
+    ],
+    "header1": [
+      "value1",
+      "value11"
     ]
   },
   "queryStringParameters": {


### PR DESCRIPTION
*Issue #, if available:* #220

*Description of changes:*

This solution builds upon @jeromevdl 's solution of PR [234](https://github.com/aws/aws-lambda-java-libs/pull/234) to fix the
issue of headers being case sensitive. Fixes @carlzogh 's comment
regarding breaking changes in setHeaders.

This adds some extra unit tests, and reorders some of the added unit test assertions of the original PR, too

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.



_Original PR: #298, I closed that PR by accident due to deleting and re-creating the branch from v4 as a base_