### PR TITLE
1.2.2 lambda-java-core release

### DIFF
--- a/aws-lambda-java-core/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-core/RELEASE.CHANGELOG.md
@@ -1,3 +1,8 @@
+### August 30, 2022
+`1.2.2`:
+- Added new `CustomPojoSerializer` interface
+- Removed unnecessary usage of public on interface methods (aws#172) 
+
 ### April 28, 2020
 `1.2.1`:
 - Added missing XML namespace declarations to `pom.xml` file ([#97](https://github.com/aws/aws-lambda-java-libs/issues/97))

--- a/aws-lambda-java-core/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-core/RELEASE.CHANGELOG.md
@@ -1,4 +1,4 @@
-### August 30, 2022
+### November 09, 2022
 `1.2.2`:
 - Added new `CustomPojoSerializer` interface
 - Removed unnecessary usage of public on interface methods (aws#172) 

--- a/aws-lambda-java-core/pom.xml
+++ b/aws-lambda-java-core/pom.xml
@@ -5,7 +5,7 @@
   
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-core</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <packaging>jar</packaging>
   
   <name>AWS Lambda Java Core Library</name>

--- a/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/CustomPojoSerializer.java
+++ b/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/CustomPojoSerializer.java
@@ -1,0 +1,14 @@
+/* Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+package com.amazonaws.services.lambda.runtime;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.lang.reflect.Type;
+
+public interface CustomPojoSerializer {
+    <T> T fromJson(InputStream input, Type type);
+    <T> T fromJson(String input, Type type);
+    <T> void toJson(T value, OutputStream output, Type type);
+} 

--- a/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/CustomPojoSerializer.java
+++ b/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/CustomPojoSerializer.java
@@ -7,8 +7,32 @@ import java.io.OutputStream;
 
 import java.lang.reflect.Type;
 
+/**
+ * Interface required to implement a custom plain old java objects serializer
+ */
 public interface CustomPojoSerializer {
+
+    /**
+     * Deserializes from input stream to plain old java object
+     * @param input input stream
+     * @param type plain old java object type
+     * @return deserialized plain old java object of type T
+     */
     <T> T fromJson(InputStream input, Type type);
+
+    /**
+     * Deserializes from String to plain old java object
+     * @param input input string
+     * @param type plain old java object type
+     * @return deserialized plain old java object of type T
+     */
     <T> T fromJson(String input, Type type);
+
+    /**
+     * Serializes plain old java object to output stream
+     * @param value instance of type T to be serialized
+     * @param output OutputStream to serialize plain old java object to
+     * @param type plain old java object type
+     */
     <T> void toJson(T value, OutputStream output, Type type);
-} 
+}


### PR DESCRIPTION
*Description of changes:*
### August 30, 2022
`1.2.2`:
- Added new `CustomPojoSerializer` interface
- Removed unnecessary usage of public on interface methods (aws#172) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
