### PR TITLE
Support sockets as transport for framed telemetry

### DIFF
--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/logging/FramedTelemetryLogSink.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/logging/FramedTelemetryLogSink.java
@@ -2,7 +2,7 @@
 
 package com.amazonaws.services.lambda.runtime.api.client.logging;
 
-import java.io.File;
+import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -31,8 +31,8 @@ public class FramedTelemetryLogSink implements LogSink {
     private final FileOutputStream logOutputStream;
     private final ByteBuffer headerBuf;
 
-    public FramedTelemetryLogSink(File file) throws IOException {
-        this.logOutputStream = new FileOutputStream(file);
+    public FramedTelemetryLogSink(FileDescriptor fd) throws IOException {
+        this.logOutputStream = new FileOutputStream(fd);
         this.headerBuf = ByteBuffer.allocate(HEADER_LENGTH).order(ByteOrder.BIG_ENDIAN);
     }
 

--- a/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/logging/FramedTelemetryLogSinkTest.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/logging/FramedTelemetryLogSinkTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.FileDescriptor;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
@@ -29,7 +31,9 @@ public class FramedTelemetryLogSinkTest {
     public void logSingleFrame() throws IOException {
         byte[] message = "hello world\nsomething on a new line!\n".getBytes();
         File tmpFile = tmpFolder.resolve("pipe").toFile();
-        try (FramedTelemetryLogSink logSink = new FramedTelemetryLogSink(tmpFile)) {
+        FileOutputStream fos = new FileOutputStream(tmpFile);
+        FileDescriptor fd = fos.getFD();
+        try (FramedTelemetryLogSink logSink = new FramedTelemetryLogSink(fd)) {
             logSink.log(message);
         }
 
@@ -63,7 +67,9 @@ public class FramedTelemetryLogSinkTest {
         byte[] firstMessage = "hello world\nsomething on a new line!".getBytes();
         byte[] secondMessage = "hello again\nhere's another message\n".getBytes();
         File tmpFile = tmpFolder.resolve("pipe").toFile();
-        try (FramedTelemetryLogSink logSink = new FramedTelemetryLogSink(tmpFile)) {
+        FileOutputStream fos = new FileOutputStream(tmpFile);
+        FileDescriptor fd = fos.getFD();
+        try (FramedTelemetryLogSink logSink = new FramedTelemetryLogSink(fd)) {
             logSink.log(firstMessage);
             logSink.log(secondMessage);
         }
@@ -107,7 +113,9 @@ public class FramedTelemetryLogSinkTest {
         try {
             byte[] message = "hello world\nsomething on a new line!\n".getBytes();
             File tmpFile = tmpFolder.resolve("pipe").toFile();
-            try (FramedTelemetryLogSink logSink = new FramedTelemetryLogSink(tmpFile)) {
+            FileOutputStream fos = new FileOutputStream(tmpFile);
+            FileDescriptor fd = fos.getFD();
+            try (FramedTelemetryLogSink logSink = new FramedTelemetryLogSink(fd)) {
                 Thread.currentThread().interrupt();
 
                 logSink.log(message);


### PR DESCRIPTION
*Description of changes:*

Socket cannot be re-opened (unlike pipes and regular files). We we have to reflectively construct the `FileDescriptor` with the right number as it does not have a constructor that takes int.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
