### PR TITLE
Update S3Event.java with implements Serializable to support native ja…

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/s3/S3Event.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/s3/S3Event.java
@@ -54,7 +54,7 @@ public class S3Event implements Serializable {
     @Builder(setterPrefix = "with")
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class UserIdentityEntity {
+    public static class UserIdentityEntity implements Serializable {
 
         private String principalId;
 
@@ -64,7 +64,7 @@ public class S3Event implements Serializable {
     @Builder(setterPrefix = "with")
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class S3BucketEntity {
+    public static class S3BucketEntity implements Serializable{
 
         private String name;
         private UserIdentityEntity ownerIdentity;
@@ -76,7 +76,7 @@ public class S3Event implements Serializable {
     @Builder(setterPrefix = "with")
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class S3ObjectEntity {
+    public static class S3ObjectEntity implements Serializable{
 
         private String key;
         private Long size;
@@ -120,7 +120,7 @@ public class S3Event implements Serializable {
     @Builder(setterPrefix = "with")
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class S3Entity {
+    public static class S3Entity implements Serializable{
 
         private String configurationId;
         private S3BucketEntity bucket;
@@ -133,7 +133,7 @@ public class S3Event implements Serializable {
     @Builder(setterPrefix = "with")
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class RequestParametersEntity {
+    public static class RequestParametersEntity implements Serializable{
 
         private String sourceIPAddress;
 
@@ -143,7 +143,7 @@ public class S3Event implements Serializable {
     @Builder(setterPrefix = "with")
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ResponseElementsEntity {
+    public static class ResponseElementsEntity implements Serializable{
 
         @JsonProperty("x-amz-id-2")
         private String xAmzId2;
@@ -157,7 +157,7 @@ public class S3Event implements Serializable {
     @Builder(setterPrefix = "with")
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class S3EventNotificationRecord {
+    public static class S3EventNotificationRecord implements Serializable{
 
         private String awsRegion;
         private String eventName;


### PR DESCRIPTION
…va runtime hints

Update S3Event.java with implements Serializable to support native java runtime hints. In order to hint to GraalVM runtime hints that a class is to be included for serialization, it needs to implement Serializable interface. Can we please add this change.
Reference: https://docs.spring.io/spring-framework/docs/6.0.2/javadoc-api/org/springframework/aot/hint/SerializationHints.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
