### PR TITLE
Add target to publish dev snapshots to a maven repository

### DIFF
--- a/aws-lambda-java-runtime-interface-client/.gitignore
+++ b/aws-lambda-java-runtime-interface-client/.gitignore
@@ -1,1 +1,2 @@
 compile-flags.txt
+ric-dev-environment/dev-maven-repo.mk

--- a/aws-lambda-java-runtime-interface-client/Makefile
+++ b/aws-lambda-java-runtime-interface-client/Makefile
@@ -4,6 +4,10 @@ ARCHITECTURE := $(shell arch)
 ARCHITECTURE_ALIAS := $($(shell echo "$(ARCHITECTURE)_ALIAS"))
 ARCHITECTURE_ALIAS := $(or $(ARCHITECTURE_ALIAS),amd64) # on any other archs defaulting to amd64
 
+# This optional module exports MAVEN_REPO_URL, MAVEN_REPO_USERNAME and MAVEN_REPO_PASSWORD environment variables
+# making it possible to publish resulting artifacts to a development maven repository
+-include ric-dev-environment/dev-maven-repo.mk
+
 .PHONY: target
 target:
 	$(info ${HELP_MESSAGE})
@@ -41,6 +45,10 @@ pr: test test-smoke
 .PHONY: build
 build: 
 	mvn clean install
+
+.PHONY: publish
+publish:
+	mvn deploy --settings ric-dev-environment/settings.xml
 
 define HELP_MESSAGE
 

--- a/aws-lambda-java-runtime-interface-client/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/pom.xml
@@ -36,7 +36,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jacoco.maven.plugin.version>0.8.7</jacoco.maven.plugin.version>
+    <jacoco.maven.plugin.version>0.8.8</jacoco.maven.plugin.version>
     <!-- 
         The test/integration/codebuild/buildspec.*.yml files will set -DmultiArch=false
         as a workaround for executing within Github Actions. At time of writing (2022-04-08) the 
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.10.1</version>
         <configuration>
           <encoding>UTF-8</encoding>
           <source>${maven.compiler.source}</source>
@@ -125,6 +125,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifest>
@@ -183,6 +184,17 @@
   <profiles>
     <profile>
       <id>dev</id>
+      <activation>
+        <file>
+          <exists>ric-dev-environment/dev-maven-repo.mk</exists>
+        </file>
+      </activation>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>dev-snapshot-repo</id>
+          <url>${env.MAVEN_REPO_URL}</url>
+        </snapshotRepository>
+      </distributionManagement>
       <build>
         <plugins>
           <plugin>

--- a/aws-lambda-java-runtime-interface-client/ric-dev-environment/settings.xml
+++ b/aws-lambda-java-runtime-interface-client/ric-dev-environment/settings.xml
@@ -1,0 +1,25 @@
+<settings>
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <activation>
+                <file>
+                    <exists>dev-maven-repo.mk</exists>
+                </file>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>dev-snapshot-repo</id>
+                    <url>${env.MAVEN_REPO_URL}</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+    <servers>
+        <server>
+            <id>dev-snapshot-repo</id>
+            <username>${env.MAVEN_REPO_USERNAME}</username>
+            <password>${env.MAVEN_REPO_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
*Description of changes:*
Add `publish` make target, which allows publishing snapshot artifact to a specified repository. Repository credentials should be defined and exported in/from `ric-dev-environment/dev-maven-repo.mk` and include `MAVEN_REPO_URL`, `MAVEN_REPO_PASSWORD`, `MAVEN_REPO_USERNAME`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
