### PR TITLE
Update apache-maven to 3.8.7

### DIFF
--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/Dockerfile.agent
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/Dockerfile.agent
@@ -3,7 +3,7 @@ FROM public.ecr.aws/amazoncorretto/amazoncorretto:8
 ARG ARCHITECTURE="amd64"
 
 ENV DOCKER_CLI_PLUGIN_DIR="/root/.docker/cli-plugins"
-ENV PATH="$PATH:/tmp/apache-maven-3.8.6/bin"
+ENV PATH="$PATH:/tmp/apache-maven-3.8.7/bin"
 
 RUN amazon-linux-extras enable docker && \
     yum clean metadata && \
@@ -16,5 +16,5 @@ RUN wget \
 RUN chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
 
 WORKDIR /tmp
-RUN curl -O https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz && \
-    tar xf apache-maven-3.8.6-bin.tar.gz
+RUN curl -O https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz && \
+    tar xf apache-maven-3.8.7-bin.tar.gz


### PR DESCRIPTION
*Description of changes:*
Update apache-maven to `3.8.7` in `test/integration/codebuild-local`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
