### PR TITLE
Adding reference to calling class for reflection issue in unit tests.

### DIFF
--- a/aws-lambda-java-tests/src/main/java/com/amazonaws/services/lambda/runtime/tests/EventLoader.java
+++ b/aws-lambda-java-tests/src/main/java/com/amazonaws/services/lambda/runtime/tests/EventLoader.java
@@ -117,10 +117,7 @@ public class EventLoader {
 
         PojoSerializer<T> serializer = LambdaEventSerializers.serializerFor(targetClass, ClassLoader.getSystemClassLoader());
 
-        InputStream stream = serializer.getClass().getResourceAsStream(filename);
-        if (stream == null) {
-            stream = serializer.getClass().getClassLoader().getResourceAsStream(filename);
-        }
+        InputStream stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(filename);
         if (stream == null) {
             try {
                 stream = new FileInputStream(new File(filename));

--- a/aws-lambda-java-tests/src/main/java/com/amazonaws/services/lambda/runtime/tests/EventsArgumentsProvider.java
+++ b/aws-lambda-java-tests/src/main/java/com/amazonaws/services/lambda/runtime/tests/EventsArgumentsProvider.java
@@ -36,10 +36,7 @@ public class EventsArgumentsProvider implements ArgumentsProvider, AnnotationCon
                         return Arguments.of(EventLoader.loadEvent(event.value(), clazz));
                     });
         } else {
-            URL folderUrl = getClass().getResource(events.folder());
-            if (folderUrl == null) {
-                folderUrl = getClass().getClassLoader().getResource(events.folder());
-            }
+            URL folderUrl = Thread.currentThread().getContextClassLoader().getResource(events.folder());
             if (folderUrl == null) {
                 throw new IllegalArgumentException("Path " + events.folder() + " cannot be found");
             }

--- a/aws-lambda-java-tests/src/main/java/com/amazonaws/services/lambda/runtime/tests/HandlerParamsArgumentsProvider.java
+++ b/aws-lambda-java-tests/src/main/java/com/amazonaws/services/lambda/runtime/tests/HandlerParamsArgumentsProvider.java
@@ -118,10 +118,7 @@ public class HandlerParamsArgumentsProvider implements ArgumentsProvider, Annota
     }
 
     private Stream<Path> listFiles(String folder) throws IOException, URISyntaxException {
-        URL folderUrl = getClass().getResource(folder);
-        if (folderUrl == null) {
-            folderUrl = getClass().getClassLoader().getResource(folder);
-        }
+        URL folderUrl = Thread.currentThread().getContextClassLoader().getResource(folder);
         if (folderUrl == null) {
             throw new IllegalArgumentException("Path " + folder + " cannot be found");
         }


### PR DESCRIPTION
*Issue #, if available:* Although I have not raised an issue for this, if what I describe is reproducible by others, I propose the changes in this pull request to resolve the issue. I noticed this evening when I started writing unit tests that the HandlerParamsArguments option was not working with either just events or events and responses combined as I continued to get the "Path /resources/events/ cannot be found" IllegalArgumentException. I tried all variations of passing in the folder location. To test that my path was correct, I created a test program using the same methods and logic as the methods being called, which confirmed that the issue was not with the path string. I then walked through the debugger in my unit test and it showed that the class that was considered the caller and passed to the getResource and getResourceAsStream methods was the AWS class. I would note that the only reason the single event loader works is because of the "stream = new FileInputStream(new File(filename));" line - the other first two attempts to set the input stream likewise return null.  All unit tests pass following my changes, and if you believe a better solution exists, I'm all for it. I just want to enable the multi-events and responses feature in my unit tests. Thanks!

*Description of changes:* The changes in this PR 1) add a reference to the calling class to obtain files and folders and 2) remove the extraneous attempts to get the file or folder path that always resulted in null.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
