### PR TITLE
Release aws-lambda-java-runtime-interface-client, version 2.2.0

### DIFF
--- a/aws-lambda-java-runtime-interface-client/README.md
+++ b/aws-lambda-java-runtime-interface-client/README.md
@@ -70,7 +70,7 @@ pom.xml
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-      <version>2.1.1</version>
+      <version>2.2.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/aws-lambda-java-runtime-interface-client/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-runtime-interface-client/RELEASE.CHANGELOG.md
@@ -1,3 +1,11 @@
+### February 3, 2022
+`2.2.0`
+- Added timestamps to TLV
+- Removed legacy `init` method support
+- libcurl updated to version 7.86
+- Support sockets as transport for framed telemetry
+- Updated aws-lambda-java-core to 1.2.2
+
 ### April 11, 2022
 `2.1.1`
 - fix: Re-build of the x86_64/aarch64 artifacts

--- a/aws-lambda-java-runtime-interface-client/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-  <version>2.1.1</version>
+  <version>2.2.0</version>
   <packaging>jar</packaging>
 
   <name>AWS Lambda Java Runtime Interface Client</name>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-core</artifactId>
-      <version>1.2.1</version>
+      <version>1.2.2</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
*Description of changes:*
Staging version 2.2.0 of RIC

- Added timestamps to TLV
- Removed legacy `init` method support
- libcurl updated to version 7.86
- Support sockets as transport for framed telemetry
- Updated aws-lambda-java-core to 1.2.2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
