### PR TITLE
install buildx from docker/buildx-bin:latest

### DIFF
--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/Dockerfile.agent
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/Dockerfile.agent
@@ -1,20 +1,14 @@
 FROM public.ecr.aws/amazoncorretto/amazoncorretto:8
 
-ARG ARCHITECTURE="amd64"
-
-ENV DOCKER_CLI_PLUGIN_DIR="/root/.docker/cli-plugins"
-ENV PATH="$PATH:/tmp/apache-maven-3.8.7/bin"
-
+# Install docker and buildx extension
 RUN amazon-linux-extras enable docker && \
     yum clean metadata && \
-    yum install -y docker tar gzip unzip file wget
+    yum install -y docker tar gzip unzip file
 
-RUN mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
-RUN wget \
-    "$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE}" | cut -d '"' -f 4)" \
-     -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-RUN chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
+COPY --from=docker/buildx-bin:latest /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
-WORKDIR /tmp
-RUN curl -O https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz && \
-    tar xf apache-maven-3.8.7-bin.tar.gz
+# Install maven from apache.org, as version in the yum repository doesn't support latest maven plugins
+ENV PATH="$PATH:/apache-maven/bin"
+RUN mkdir /apache-maven && \
+    curl https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz | \
+    tar -xz -C /apache-maven --strip-components 1

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/configure_multi_arch_env.sh
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/scripts/configure_multi_arch_env.sh
@@ -6,25 +6,17 @@ set -euo pipefail
 echo "Setting up multi-arch build environment"
 ARCHITECTURE=$(arch)
 if [[ "$ARCHITECTURE" == "x86_64" ]]; then
-	ARCHITECTURE_ALIAS="amd64"
 	TARGET_EMULATOR="arm64"
 elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
-	ARCHITECTURE_ALIAS="arm64"
 	TARGET_EMULATOR="amd64"
 else
 	echo "Architecture $ARCHITECTURE is not currently supported."
 	exit 1
 fi
+
 echo "Installing ${TARGET_EMULATOR} emulator"
 docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
 docker run --rm --privileged public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install ${TARGET_EMULATOR}
-# Install buildx plugin only if not already present (i.e. it's installed for the local-agent)
-if [[ ! -f "${DOCKER_CLI_PLUGIN_DIR}/docker-buildx" ]]; then
-	echo "docker-buildx not found, installing now"
-	mkdir -p "${DOCKER_CLI_PLUGIN_DIR}"
-	BUILDX_URL=$(curl https://api.github.com/repos/docker/buildx/releases/latest | grep browser_download_url | grep "linux-${ARCHITECTURE_ALIAS}" | cut -d '"' -f 4)
-	wget "${BUILDX_URL}" -O "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-	chmod +x "${DOCKER_CLI_PLUGIN_DIR}"/docker-buildx
-fi
 echo "Setting docker build command to default to buildx"
+echo "Docker buildx version: $(docker buildx version)"
 docker buildx install


### PR DESCRIPTION
*Description of changes:*
This change fixes smoke tests by installing `buildx` docker extension from the official docker image.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
