### PR TITLE
1.0.2 lambda-java-serialization release

### DIFF
--- a/aws-lambda-java-serialization/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-serialization/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### February 09, 2023
+`1.0.2`:
+- Updated `gson` dependency from 2.8.9 to 2.10.1
+
 ### November 21, 2022
 `1.0.1`:
 - Updated `jackson-databind` dependency from 2.12.6.1 to 2.13.4.1

--- a/aws-lambda-java-serialization/pom.xml
+++ b/aws-lambda-java-serialization/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-serialization</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Runtime Serialization</name>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.9</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
*Description of changes:*

**1.0.2 lambda-java-serialization release:**
* Update Gson to `2.10.1`



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
