### PR TITLE
1.1.0 lambda-java-serialization release

### DIFF
--- a/aws-lambda-java-serialization/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-serialization/RELEASE.CHANGELOG.md
@@ -1,3 +1,8 @@
+### February 17, 2023
+`1.1.0`:
+- Update `jackson-databind` dependency from 2.13.4.1 to 2.14.2
+- Register `JavaTimeModule` and `Jdk8Module` modules to `jackson-databind`
+
 ### February 09, 2023
 `1.0.2`:
 - Updated `gson` dependency from 2.8.9 to 2.10.1

--- a/aws-lambda-java-serialization/pom.xml
+++ b/aws-lambda-java-serialization/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-serialization</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Runtime Serialization</name>
@@ -32,6 +32,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <relocation.prefix>com.amazonaws.lambda.thirdparty</relocation.prefix>
+        <jackson.version>2.14.2</jackson.version>
+        <gson.version>2.10.1</gson.version>
         <junit.version>5.9.1</junit.version>
         <owasp.version>7.3.2</owasp.version>
     </properties>
@@ -41,12 +43,22 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.1</version>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10.1</version>
+            <version>${gson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/aws-lambda-java-serialization/src/main/java/com/amazonaws/services/lambda/runtime/serialization/factories/JacksonFactory.java
+++ b/aws-lambda-java-serialization/src/main/java/com/amazonaws/services/lambda/runtime/serialization/factories/JacksonFactory.java
@@ -5,6 +5,8 @@ package com.amazonaws.services.lambda.runtime.serialization.factories;
 import com.amazonaws.services.lambda.runtime.serialization.PojoSerializer;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationConfig;
@@ -19,7 +21,10 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -50,24 +55,42 @@ public class JacksonFactory implements PojoSerializerFactory {
 
 
     private static ObjectMapper createObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper(createJsonFactory());
+        ObjectMapper mapper = JsonMapper.builder(createJsonFactory())
+                .enable(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS)                       // this is default as of 2.2.0
+                .enable(MapperFeature.AUTO_DETECT_FIELDS)                                   // this is default as of 2.0.0
+                .enable(MapperFeature.AUTO_DETECT_GETTERS)                                  // this is default as of 2.0.0
+                .enable(MapperFeature.AUTO_DETECT_IS_GETTERS)                               // this is default as of 2.0.0
+                .enable(MapperFeature.AUTO_DETECT_SETTERS)                                  // this is default as of 2.0.0
+                .enable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)                        // this is default as of 2.0.0
+                .enable(MapperFeature.USE_STD_BEAN_NAMING)
+                .enable(MapperFeature.USE_ANNOTATIONS)                                      // this is default as of 2.0.0
+                .disable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)                  // this is default as of 2.5.0
+                .disable(MapperFeature.AUTO_DETECT_CREATORS)
+                .disable(MapperFeature.INFER_PROPERTY_MUTATORS)
+                .disable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)                      // this is default as of 2.0.0
+                .disable(MapperFeature.USE_GETTERS_AS_SETTERS)
+                .disable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME)                   // this is default as of 2.1.0
+                .disable(MapperFeature.USE_STATIC_TYPING)                                   // this is default as of 2.0.0
+                .disable(MapperFeature.REQUIRE_SETTERS_FOR_GETTERS)                         // this is default as of 2.0.0
+                .build();
+
         SerializationConfig scfg = mapper.getSerializationConfig();
         scfg = scfg.withFeatures(
-                SerializationFeature.FAIL_ON_SELF_REFERENCES,
-                SerializationFeature.FAIL_ON_UNWRAPPED_TYPE_IDENTIFIERS,
-                SerializationFeature.WRAP_EXCEPTIONS
-                );
+                SerializationFeature.FAIL_ON_SELF_REFERENCES,                               // this is default as of 2.4.0
+                SerializationFeature.FAIL_ON_UNWRAPPED_TYPE_IDENTIFIERS,                    // this is default as of 2.4.0
+                SerializationFeature.WRAP_EXCEPTIONS                                        // this is default as of 2.0.0
+        );
         scfg = scfg.withoutFeatures(
-                SerializationFeature.CLOSE_CLOSEABLE, 
+                SerializationFeature.CLOSE_CLOSEABLE,                                       // this is default as of 2.0.0
                 SerializationFeature.EAGER_SERIALIZER_FETCH,
                 SerializationFeature.FAIL_ON_EMPTY_BEANS,
                 SerializationFeature.FLUSH_AFTER_WRITE_VALUE,
-                SerializationFeature.INDENT_OUTPUT,
-                SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS,
-                SerializationFeature.USE_EQUALITY_FOR_OBJECT_ID,
-                SerializationFeature.WRITE_CHAR_ARRAYS_AS_JSON_ARRAYS,
-                SerializationFeature.WRAP_ROOT_VALUE
-                );
+                SerializationFeature.INDENT_OUTPUT,                                         // this is default as of 2.5.0
+                SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS,                             // this is default as of 2.0.0
+                SerializationFeature.USE_EQUALITY_FOR_OBJECT_ID,                            // this is default as of 2.3.0
+                SerializationFeature.WRITE_CHAR_ARRAYS_AS_JSON_ARRAYS,                      // this is default as of 2.0.0
+                SerializationFeature.WRAP_ROOT_VALUE                                        // this is default as of 2.2.0
+        );
         mapper.setConfig(scfg);
 
         DeserializationConfig dcfg = mapper.getDeserializationConfig();
@@ -75,43 +98,28 @@ public class JacksonFactory implements PojoSerializerFactory {
                 DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT,
                 DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT,
                 DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY,
-                DeserializationFeature.FAIL_ON_INVALID_SUBTYPE,
-                DeserializationFeature.FAIL_ON_UNRESOLVED_OBJECT_IDS,
+                DeserializationFeature.FAIL_ON_INVALID_SUBTYPE,                             // this is default as of 2.2.0
+                DeserializationFeature.FAIL_ON_UNRESOLVED_OBJECT_IDS,                       // this is default as of 2.5.0
                 DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL,
                 DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS,
-                DeserializationFeature.WRAP_EXCEPTIONS
-                );
+                DeserializationFeature.WRAP_EXCEPTIONS                                      // this is default as of 2.0.0
+        );
         dcfg = dcfg.withoutFeatures(
-                DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES,
-                DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES,
-                DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS,
-                DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY,
+                DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES,                          // this is default as of 2.3.0
+                DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES,                         // this is default as of 2.0.0
+                DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS,                           // this is default as of 2.0.0
+                DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY,                        // this is default as of 2.3.0
                 DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
-                );
+        );
         mapper.setConfig(dcfg);
-        mapper.setSerializationInclusion(Include.NON_NULL); //NON_EMPTY?
-
-        mapper.enable(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS);
-        mapper.enable(MapperFeature.AUTO_DETECT_FIELDS);
-        mapper.enable(MapperFeature.AUTO_DETECT_GETTERS);
-        mapper.enable(MapperFeature.AUTO_DETECT_IS_GETTERS);
-        mapper.enable(MapperFeature.AUTO_DETECT_SETTERS);
-        mapper.enable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS);
-        mapper.enable(MapperFeature.USE_STD_BEAN_NAMING);
-        mapper.enable(MapperFeature.USE_ANNOTATIONS);
-
-        mapper.disable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
-        mapper.disable(MapperFeature.AUTO_DETECT_CREATORS);
-        mapper.disable(MapperFeature.INFER_PROPERTY_MUTATORS);
-        mapper.disable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
-        mapper.disable(MapperFeature.USE_GETTERS_AS_SETTERS);
-        mapper.disable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME);
-        mapper.disable(MapperFeature.USE_STATIC_TYPING);
-        mapper.disable(MapperFeature.REQUIRE_SETTERS_FOR_GETTERS);
+        mapper.setSerializationInclusion(Include.NON_NULL);
 
         SimpleModule module = new SimpleModule();
         module.addDeserializer(Void.class, new VoidDeserializer());
         mapper.registerModule(module);
+
+        mapper.registerModule(new JavaTimeModule());
+        mapper.registerModule(new Jdk8Module());
 
         return mapper;
     }
@@ -138,33 +146,42 @@ public class JacksonFactory implements PojoSerializerFactory {
     }
 
     private static JsonFactory createJsonFactory() {
-        JsonFactory factory = new JsonFactory();
-        //Json Parser enabled
-        factory.enable(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS);
-        factory.enable(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS);
-        factory.enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES);
-        factory.enable(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER);
-        factory.enable(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS);
-        factory.enable(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES);
+        JsonFactory factory = JsonFactory.builder()
+                //Json Read enabled
+                .enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
+                .enable(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS)
+                .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                .enable(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER)
+                .enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS)
+                .enable(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES)
+
+                //Json Read disabled
+                .disable(JsonReadFeature.ALLOW_JAVA_COMMENTS)                               // this is default as of 2.10.0
+                .disable(JsonReadFeature.ALLOW_YAML_COMMENTS)                               // this is default as of 2.10.0
+
+                //Json Write enabled
+                .enable(JsonWriteFeature.QUOTE_FIELD_NAMES)                                 // this is default as of 2.10.0
+                .enable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)                              // this is default as of 2.10.0
+
+                //Json Write disabled
+                .disable(JsonWriteFeature.ESCAPE_NON_ASCII)                                 // this is default as of 2.10.0
+                .disable(JsonWriteFeature.WRITE_NUMBERS_AS_STRINGS)                         // this is default as of 2.10.0
+                .build();
 
         //Json Parser disabled
-        factory.disable(JsonParser.Feature.ALLOW_COMMENTS);
-        factory.disable(JsonParser.Feature.ALLOW_YAML_COMMENTS);
         factory.disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
         factory.disable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
 
-        //Json generator enabled
+        //Json Generator enabled
         factory.enable(JsonGenerator.Feature.IGNORE_UNKNOWN);
-        factory.enable(JsonGenerator.Feature.QUOTE_FIELD_NAMES);
-        factory.enable(JsonGenerator.Feature.QUOTE_NON_NUMERIC_NUMBERS);
-        //Json generator disabled
+
+        //Json Generator disabled
         factory.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
         factory.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
-        factory.disable(JsonGenerator.Feature.ESCAPE_NON_ASCII);
         factory.disable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM);
-        factory.disable(JsonGenerator.Feature.STRICT_DUPLICATE_DETECTION);
-        factory.disable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);
-        factory.disable(JsonGenerator.Feature.WRITE_NUMBERS_AS_STRINGS);
+        factory.disable(JsonGenerator.Feature.STRICT_DUPLICATE_DETECTION);                  // this is default as of 2.3.0
+        factory.disable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);                   // this is default as of 2.3.0
+
         return factory;
     }
 
@@ -206,7 +223,7 @@ public class JacksonFactory implements PojoSerializerFactory {
 
     private static final class TypeSerializer extends InternalSerializer<Object> {
         public TypeSerializer(ObjectMapper mapper, JavaType type) {
-            super(mapper.reader(type), mapper.writerFor(type));
+            super(mapper.readerFor(type), mapper.writerFor(type));
         }
 
         public TypeSerializer(ObjectMapper mapper, Type type) {
@@ -216,7 +233,7 @@ public class JacksonFactory implements PojoSerializerFactory {
 
     private static final class ClassSerializer<T> extends InternalSerializer<T> {
         public ClassSerializer(ObjectMapper mapper, Class<T> clazz) {
-            super(mapper.reader(clazz), mapper.writerFor(clazz));
+            super(mapper.readerFor(clazz), mapper.writerFor(clazz));
         }
     }
 


### PR DESCRIPTION
*Description of changes:*
**1.1.0 lambda-java-serialization release:**
- Update `jackson-databind` dependency from 2.13.4.1 to 2.14.2
- Register `JavaTimeModule` and `Jdk8Module` modules to `jackson-databind`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
