### PR TITLE
1.1.1 lambda-java-serialization release

### DIFF
--- a/aws-lambda-java-serialization/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-serialization/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### February 22, 2023
+`1.1.1`:
+- Register `JodaModule` to JacksonFactory
+
 ### February 17, 2023
 `1.1.0`:
 - Update `jackson-databind` dependency from 2.13.4.1 to 2.14.2

--- a/aws-lambda-java-serialization/pom.xml
+++ b/aws-lambda-java-serialization/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-serialization</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Runtime Serialization</name>
@@ -43,6 +43,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
@@ -229,6 +234,10 @@
                                 <relocation>
                                     <pattern>com.google.gson</pattern>
                                     <shadedPattern>${relocation.prefix}.com.google.gson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.joda.time</pattern>
+                                    <shadedPattern>${relocation.prefix}.org.joda.time</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.json</pattern>

--- a/aws-lambda-java-serialization/src/main/java/com/amazonaws/services/lambda/runtime/serialization/events/modules/DateTimeModule.java
+++ b/aws-lambda-java-serialization/src/main/java/com/amazonaws/services/lambda/runtime/serialization/events/modules/DateTimeModule.java
@@ -6,25 +6,23 @@ import com.amazonaws.services.lambda.runtime.serialization.util.SerializeUtil;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.json.PackageVersion;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 import java.io.IOException;
 
 /**
  * Class that is used to load customer DateTime class
  */
-public class DateTimeModule extends SimpleModule {
+public class DateTimeModule extends JodaModule {
 
     /**
      * creates a DateTimeModule using customer class loader to pull org.joda.time.DateTime
      */
     public DateTimeModule(ClassLoader classLoader) {
-        super(PackageVersion.VERSION);
         Class dateTimeClass = SerializeUtil.loadCustomerClass("org.joda.time.DateTime", classLoader);
         this.addSerializer(dateTimeClass, getSerializer(dateTimeClass, classLoader));
         this.addDeserializer(dateTimeClass, getDeserializer(dateTimeClass));

--- a/aws-lambda-java-serialization/src/test/java/com/amazonaws/services/lambda/runtime/serialization/events/LambdaEventSerializersTest.java
+++ b/aws-lambda-java-serialization/src/test/java/com/amazonaws/services/lambda/runtime/serialization/events/LambdaEventSerializersTest.java
@@ -5,7 +5,6 @@ package com.amazonaws.services.lambda.runtime.serialization.events;
 import com.amazonaws.services.lambda.runtime.events.*;
 import com.amazonaws.services.lambda.runtime.serialization.PojoSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;


### PR DESCRIPTION
*Description of changes:*
### 1.1.1 lambda-java-serialization release:
* Register `JodaModule` to JacksonFactory


`jackson-databind >= v2.12.0` explicitly fails (de)serialization of `org.joda.time.*` types in absence of registered custom (de)serializers. [PR #2776](https://github.com/FasterXML/jackson-databind/issues/2776)

Registering `JodaModule` module is required to (de)serialize `org.joda.time.*` types.

*Test*:
EventsV3 unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
