### PR TITLE
Modifying AppSyncLambdaAuthorizerEvent to incude requestHeaders

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/AppSyncLambdaAuthorizerEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/AppSyncLambdaAuthorizerEvent.java
@@ -30,6 +30,7 @@ public class AppSyncLambdaAuthorizerEvent {
 
     private RequestContext requestContext;
     private String authorizationToken;
+    private MutableMap<CharSequence, Any> requestHeaders;
 
     @Data
     @Builder(setterPrefix = "with")


### PR DESCRIPTION
*Issue #, if available:* NONE

*Description of changes:* I, as part of the AWS Appsync team would like to update our lambda authorizers to accomodate request headers in input event.

*Target (OCI, Managed Runtime, both):* both


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
