### PR TITLE
Prepare platform specific jar files

### DIFF
--- a/aws-lambda-java-runtime-interface-client/Makefile
+++ b/aws-lambda-java-runtime-interface-client/Makefile
@@ -45,10 +45,18 @@ pr: test test-smoke
 .PHONY: build
 build: 
 	mvn clean install
+	mvn install -P linux-x86_64
+	mvn install -P linux_musl-x86_64
+	mvn install -P linux-aarch64
+	mvn install -P linux_musl-aarch64
 
 .PHONY: publish
 publish:
 	./ric-dev-environment/publish_snapshot.sh
+
+.PHONY: publish
+test-publish:
+	./ric-dev-environment/test-platform-specific-jar-snapshot.sh
 
 define HELP_MESSAGE
 

--- a/aws-lambda-java-runtime-interface-client/README.md
+++ b/aws-lambda-java-runtime-interface-client/README.md
@@ -151,6 +151,33 @@ DOCKERHUB_PASSWORD=<dockerhub password>
 ```
 Recommended way is to set the Docker Hub credentials in CodeBuild job by retrieving them from AWS Secrets Manager.
 
+## Configuration
+The `aws-lambda-java-runtime-interface-client` JAR is a large uber jar, which contains compiled C libraries
+for x86_64 and aarch_64 for glibc and musl LIBC implementations. If the size is an issue, you can pick a smaller
+platform-specific JAR by setting the `<classifier>`.
+```
+<!-- Platform-specific Linux x86_64 JAR -->
+<dependency>
+    <groupId>com.amazonaws</groupId>
+    <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
+    <version>2.3.2</version>
+    <classifier>linux-x86_64</classifier>
+</dependency>
+```
+
+Available platform classifiers: `linux-x86_64`, `linux-aarch_64`, `linux_musl-aarch_64`, `linux_musl-x86_64`
+
+The Lambda runtime interface client tries to load compatible library during execution, by unpacking it to a temporary
+location `/tmp/.libaws-lambda-jni.so`.
+If this behaviour is not desirable, it is possible to extract the `.so` files during build time and specify the location via
+`com.amazonaws.services.lambda.runtime.api.client.runtimeapi.NativeClient.JNI` system property, like
+```
+ENTRYPOINT [ "/usr/bin/java",
+"-Dcom.amazonaws.services.lambda.runtime.api.client.runtimeapi.NativeClient.JNI=/function/libaws-lambda-jni.linux_x86_64.so"
+"-cp", "./*",
+"com.amazonaws.services.lambda.runtime.api.client.AWSLambda" ]
+```
+
 ## Security
 
 If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.

--- a/aws-lambda-java-runtime-interface-client/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/pom.xml
@@ -44,6 +44,9 @@
             separately from the Runtime Interface Client functionality until we figure something else out.
         -->
         <multiArch>true</multiArch>
+        <target_build_os/>
+        <target_build_arch/>
+        <ric.classifier/>
     </properties>
 
     <dependencies>
@@ -119,6 +122,8 @@
                                       failonerror="true" logError="true">
                                     <arg value="${project.build.directory}"/>
                                     <arg value="${multiArch}"/>
+                                    <arg value="${target_build_os}"/>
+                                    <arg value="${target_build_arch}"/>
                                 </exec>
                             </target>
                         </configuration>
@@ -147,6 +152,11 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
                     </archive>
+                    <classifier>${ric.classifier}</classifier>
+                    <includes>
+                        <include>com/</include>
+                        <include>jni/*${ric.classifier}.so</include>
+                    </includes>
                 </configuration>
             </plugin>
             <plugin>
@@ -287,6 +297,38 @@
                     <url>${env.MAVEN_REPO_URL}</url>
                 </repository>
             </distributionManagement>
+        </profile>
+        <profile>
+            <id>linux-x86_64</id>
+            <properties>
+                <target_build_os>linux</target_build_os>
+                <target_build_arch>x86_64</target_build_arch>
+                <ric.classifier>linux-x86_64</ric.classifier>
+            </properties>
+        </profile>
+        <profile>
+            <id>linux_musl-x86_64</id>
+            <properties>
+                <target_build_os>linux_musl</target_build_os>
+                <target_build_arch>x86_64</target_build_arch>
+                <ric.classifier>linux_musl-x86_64</ric.classifier>
+            </properties>
+        </profile>
+        <profile>
+            <id>linux-aarch64</id>
+            <properties>
+                <target_build_os>linux</target_build_os>
+                <target_build_arch>aarch_64</target_build_arch>
+                <ric.classifier>linux-aarch_64</ric.classifier>
+            </properties>
+        </profile>
+        <profile>
+            <id>linux_musl-aarch64</id>
+            <properties>
+                <target_build_os>linux_musl</target_build_os>
+                <target_build_arch>aarch_64</target_build_arch>
+                <ric.classifier>linux_musl-aarch_64</ric.classifier>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/aws-lambda-java-runtime-interface-client/ric-dev-environment/publish_snapshot.sh
+++ b/aws-lambda-java-runtime-interface-client/ric-dev-environment/publish_snapshot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 set -e
 
@@ -18,5 +18,33 @@ else
     echo "Already -SNAPSHOT version"
 fi
 
-mvn -P ci-repo deploy --settings ric-dev-environment/settings.xml
-mv pom.xml.versionsBackup pom.xml
+CLASSIFIERS_ARRAY=("linux-x86_64" "linux_musl-x86_64" "linux-aarch_64" "linux_musl-aarch_64")
+
+for str in "${CLASSIFIERS_ARRAY[@]}"; do
+  FILES="${FILES}target/aws-lambda-java-runtime-interface-client-$projectVersion-$str.jar,"
+  CLASSIFIERS="${CLASSIFIERS}${str},"
+  TYPES="${TYPES}jar,"
+done
+
+# remove the last ","
+FILES=${FILES%?}
+CLASSIFIERS=${CLASSIFIERS%?}
+TYPES=${TYPES%?}
+
+mvn -B -X -P ci-repo \
+    deploy:deploy-file \
+    -DgroupId=com.amazonaws \
+    -DartifactId=aws-lambda-java-runtime-interface-client \
+    -Dpackaging=jar \
+    -Dversion=$projectVersion \
+    -Dfile=./target/aws-lambda-java-runtime-interface-client-$projectVersion.jar \
+    -Dfiles=$FILES \
+    -Dclassifiers=$CLASSIFIERS \
+    -Dtypes=$TYPES \
+    -DpomFile=pom.xml \
+    -DrepositoryId=ci-repo -Durl=$MAVEN_REPO_URL \
+    --settings ric-dev-environment/settings.xml
+
+if [ -f pom.xml.versionsBackup ]; then
+  mv pom.xml.versionsBackup pom.xml
+fi

--- a/aws-lambda-java-runtime-interface-client/ric-dev-environment/test-platform-specific-jar-snapshot.sh
+++ b/aws-lambda-java-runtime-interface-client/ric-dev-environment/test-platform-specific-jar-snapshot.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+projectVersion=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+
+
+# test uber jar
+mvn -B -X -P ci-repo \
+    dependency:get \
+    -DremoteRepositories=ci-repo::::$MAVEN_REPO_URL \
+    -Dartifact=com.amazonaws:aws-lambda-java-runtime-interface-client:${projectVersion}-SNAPSHOT \
+    -Dtransitive=false \
+    --settings ric-dev-environment/settings.xml
+
+
+PLATFORM_ARRAY=("linux-x86_64" "linux_musl-x86_64" "linux-aarch_64" "linux_musl-aarch_64")
+
+for classifier in "${PLATFORM_ARRAY[@]}"; do
+  # Test platform specific jar
+  mvn -B -P ci-repo \
+      dependency:get \
+      -DremoteRepositories=ci-repo::::$MAVEN_REPO_URL \
+      -Dartifact=com.amazonaws:aws-lambda-java-runtime-interface-client:${projectVersion}-SNAPSHOT:jar:${classifier} \
+      -Dtransitive=false \
+      --settings ric-dev-environment/settings.xml
+done

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/ClasspathLoader.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/ClasspathLoader.java
@@ -24,8 +24,6 @@ public class ClasspathLoader {
     private static final int CLASS_SUFFIX_LEN = ".class".length();
 
     static {
-        // NativeClient loads a native library and crashes if loaded here so just exclude it
-        BLOCKLIST.add("com.amazonaws.services.lambda.runtime.api.client.runtimeapi.NativeClient");
         // Ignore module info class for serialization lib
         BLOCKLIST.add("META-INF.versions.9.module-info");
     }

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/InvocationRequest.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/InvocationRequest.java
@@ -41,39 +41,61 @@ public class InvocationRequest {
      */
     private String cognitoIdentity;
 
-    /**
-     * An input stream of the invocation's request body.
-     */
-    private InputStream stream;
-
     private byte[] content;
 
     public String getId() {
         return id;
     }
 
+    public void setId(String id) {
+        this.id = id;
+    }
+
     public String getXrayTraceId() {
         return xrayTraceId;
+    }
+
+    public void setXrayTraceId(String xrayTraceId) {
+        this.xrayTraceId = xrayTraceId;
     }
 
     public String getInvokedFunctionArn() {
         return invokedFunctionArn;
     }
 
+    public void setInvokedFunctionArn(String invokedFunctionArn) {
+        this.invokedFunctionArn = invokedFunctionArn;
+    }
+
     public long getDeadlineTimeInMs() {
         return deadlineTimeInMs;
+    }
+
+    public void setDeadlineTimeInMs(long deadlineTimeInMs) {
+        this.deadlineTimeInMs = deadlineTimeInMs;
     }
 
     public String getClientContext() {
         return clientContext;
     }
 
+    public void setClientContext(String clientContext) {
+        this.clientContext = clientContext;
+    }
+
     public String getCognitoIdentity() {
         return cognitoIdentity;
+    }
+
+    public void setCognitoIdentity(String cognitoIdentity) {
+        this.cognitoIdentity = cognitoIdentity;
     }
 
     public InputStream getContentAsStream() {
         return new ByteArrayInputStream(content);
     }
 
+    public void setContent(byte[] content) {
+        this.content = content;
+    }
 }

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/LambdaRuntimeClient.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/LambdaRuntimeClient.java
@@ -38,6 +38,7 @@ public class LambdaRuntimeClient {
         this.hostname = parts[0];
         this.port = Integer.parseInt(parts[1]);
         this.invocationEndpoint = invocationEndpoint();
+        NativeClient.init();
     }
 
     public InvocationRequest waitForNextInvocation() {

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/NativeClient.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/NativeClient.java
@@ -2,66 +2,81 @@
 
 package com.amazonaws.services.lambda.runtime.api.client.runtimeapi;
 
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This module defines the native Runtime Interface Client which is responsible for all HTTP
  * interactions with the Runtime API.
  */
 class NativeClient {
-    private static final String nativeLibPath = "/tmp/.aws-lambda-runtime-interface-client";
-    private static final String architecturePathSuffix = "/" + getArchIdentifier();
-    // Implementation based on AWS CRT, but adopted to support 64-bit architectures only (ref. https://github.com/awslabs/aws-crt-java/blob/0e9c3db8b07258b57c2503cfc47c787ccef10670/src/main/java/software/amazon/awssdk/crt/CRT.java#L106-L134)
-    private static final String supported_arm_architectures = "^(aarch64.*|arm64.*)$";
-    private static final String supported_x86_architectures = "^(x8664|amd64|ia32e|em64t|x64|x86_64)$";
-    private static final String[] libsToTry = {
-            "aws-lambda-runtime-interface-client.glibc.so",
-            "aws-lambda-runtime-interface-client.musl.so",
-    };
-    private static final Throwable[] exceptions = new Throwable[libsToTry.length];
+    private static final String NATIVE_LIB_PATH = "/tmp/.libaws-lambda-jni.so";
+    public static final String NATIVE_CLIENT_JNI_PROPERTY = "com.amazonaws.services.lambda.runtime.api.client.runtimeapi.NativeClient.JNI";
 
-    static {
-        boolean loaded = false;
-        for (int i = 0; !loaded && i < libsToTry.length; ++i) {
-            try (InputStream lib = NativeClient.class.getResourceAsStream(
-                    Paths.get(architecturePathSuffix, libsToTry[i]).toString())) {
-                Files.copy(lib, Paths.get(nativeLibPath), StandardCopyOption.REPLACE_EXISTING);
-                System.load(nativeLibPath);
-                loaded = true;
+    static void init() {
+        loadJNILib();
+        initUserAgent();
+    }
+
+    private static void loadJNILib() {
+        String jniLib = System.getProperty(NATIVE_CLIENT_JNI_PROPERTY);
+        if (jniLib != null) {
+            System.load(jniLib);
+        } else {
+            String[] libsToTry = new String[]{
+                    "libaws-lambda-jni.linux-x86_64.so",
+                    "libaws-lambda-jni.linux-aarch_64.so",
+                    "libaws-lambda-jni.linux_musl-x86_64.so",
+                    "libaws-lambda-jni.linux_musl-aarch_64.so"
+            };
+            unpackAndLoadNativeLibrary(libsToTry);
+        }
+    }
+
+
+    /**
+     * Unpacks JNI library from the JAR to a temporary location and tries to load it using System.load()
+     * Implementation based on AWS CRT
+     * (ref. <a href="https://github.com/awslabs/aws-crt-java/blob/0e9c3db8b07258b57c2503cfc47c787ccef10670/src/main/java/software/amazon/awssdk/crt/CRT.java#L106-L134">...</a>)
+     *
+     * @param libsToTry - array of native libraries to try
+     */
+    static void unpackAndLoadNativeLibrary(String[] libsToTry) {
+
+        List<String> errorMessages = new ArrayList<>();
+        for (String libToTry : libsToTry) {
+            try (InputStream inputStream = NativeClient.class.getResourceAsStream(
+                    Paths.get("/jni", libToTry).toString())) {
+                if (inputStream == null) {
+                    throw new FileNotFoundException("Specified file not in the JAR: " + libToTry);
+                }
+                Files.copy(inputStream, Paths.get(NATIVE_LIB_PATH), StandardCopyOption.REPLACE_EXISTING);
+                System.load(NATIVE_LIB_PATH);
+                return;
             } catch (UnsatisfiedLinkError | Exception e) {
-                exceptions[i] = e;
+                errorMessages.add(e.getMessage());
             }
         }
-        if (!loaded) {
-            for (int i = 0; i < libsToTry.length; ++i) {
-                System.err.printf("Failed to load the native runtime interface client library %s. Exception: %s\n", libsToTry[i], exceptions[i].getMessage());
-            }
-            System.exit(-1);
+
+        for (int i = 0; i < libsToTry.length; ++i) {
+            System.err.println("Failed to load the native runtime interface client library " + libsToTry[i] +
+                    ". Exception: " + errorMessages.get(i));
         }
+        System.exit(-1);
+    }
+
+    private static void initUserAgent() {
         String userAgent = String.format(
                 "aws-lambda-java/%s-%s",
                 System.getProperty("java.vendor.version"),
                 NativeClient.class.getPackage().getImplementationVersion());
+
         initializeClient(userAgent.getBytes());
-    }
-
-    /**
-     * @return a string describing the detected architecture the RIC is executing on
-     * @throws UnknownPlatformException
-     */
-    static String getArchIdentifier() {
-        String arch = System.getProperty("os.arch");
-
-        if (arch.matches(supported_x86_architectures)) {
-            return "x86_64";
-        } else if (arch.matches(supported_arm_architectures)) {
-            return "aarch64";
-        }
-
-        throw new UnknownPlatformException("architecture not supported: " + arch);
     }
 
     static native void initializeClient(byte[] userAgent);
@@ -69,4 +84,5 @@ class NativeClient {
     static native InvocationRequest next();
 
     static native void postInvocationResponse(byte[] requestId, byte[] response);
+
 }

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/build-jni-lib.sh
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/build-jni-lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 set -euo pipefail
@@ -6,46 +6,114 @@ set -euo pipefail
 SRC_DIR=$(dirname "$0")
 DST_DIR=${1}
 MULTI_ARCH=${2}
+BUILD_OS=${3}
+BUILD_ARCH=${4}
 CURL_VERSION=7.83.1
 
-# Not using associative arrays to maintain bash 3 compatibility with building on MacOS
-# MacOS ships with bash 3 and associative arrays require bash 4+
-# Declaring a map as an array with the column character as a separator :
-declare -a ARCHITECTURES_TO_PLATFORM=(
-    "x86_64:linux/amd64"
-    "aarch64:linux/arm64/v8"
-)
+function get_docker_platform() {
+  arch=$1
 
-declare -a TARGETS=("glibc" "musl")
+  if [ "${arch}" == "x86_64" ]; then
+    echo "linux/amd64"
+  elif [ "${arch}" == "aarch_64" ]; then
+    echo "linux/arm64/v8"
+  else
+    echo "UNKNOWN_DOCKER_PLATFORM"
+  fi
+}
 
-for pair in "${ARCHITECTURES_TO_PLATFORM[@]}"; do
-    arch=${pair%%:*}
-    platform=${pair#*:}
+function get_target_os() {
+  libc_impl=$1
 
-    if [[ "${MULTI_ARCH}" != "true" ]] && [[ "$(arch)" != "${arch}" ]]; then
-        echo "multi arch build not requested and host arch is $(arch), so skipping ${arch}:${platform} ..."
-        continue
-    fi
+  if [ "${libc_impl}" == "glibc" ]; then
+    echo "linux"
+  elif [ "${libc_impl}" == "musl" ]; then
+    echo "linux_musl"
+  else
+    echo "UNKNOWN_OS"
+  fi
+}
 
-    mkdir -p "${DST_DIR}/classes/${arch}"
+function build_for_libc_arch() {
+  libc_impl=$1
+  arch=$2
+  artifact=$3
 
-    for target in "${TARGETS[@]}"; do
-        echo "Compiling the native library for target ${target} on architecture ${arch} using Docker platform ${platform}"
-        artifact="${DST_DIR}/classes/${arch}/aws-lambda-runtime-interface-client.${target}.so"
+  docker_platform=$(get_docker_platform ${arch})
 
-        if [[ "${MULTI_ARCH}" == "true" ]]; then
-            docker build --platform="${platform}" -f "${SRC_DIR}/Dockerfile.${target}" --build-arg CURL_VERSION=${CURL_VERSION} "${SRC_DIR}" -o - | tar -xOf - src/aws-lambda-runtime-interface-client.so > "${artifact}"
-        else
-            echo "multi-arch not requestsed, assuming this is a workaround to goofyness when docker buildx is enabled on Linux CI environments."
-            echo "enabling docker buildx often updates the docker api version, so assuming that docker cli is also too old to use --output type=tar, so doing alternative build-tag-run approach"
-            docker build --platform="${platform}" -t "lambda-java-jni-lib-${target}-${arch}" -f "${SRC_DIR}/Dockerfile.${target}" --build-arg CURL_VERSION=${CURL_VERSION} "${SRC_DIR}"
-            docker run --rm --entrypoint /bin/cat "lambda-java-jni-lib-${target}-${arch}" /src/aws-lambda-runtime-interface-client.so > "${artifact}"
-        fi
+  echo "Compiling the native library with libc implementation \`${libc_impl}\` on architecture \`${arch}\` using Docker platform \`${docker_platform}\`"
 
-        [ -f "${artifact}" ]
-        if ! file -b "${artifact}" | tr '-' '_' | tee /dev/stderr | grep -q "${arch}"; then
-            echo "${artifact} did not appear to be the correct architecture, check that Docker buildx is enabled"
-            exit 1
-        fi
-    done
-done
+  if [[ "${MULTI_ARCH}" == "true" ]]; then
+      docker build --platform="${docker_platform}" -f "${SRC_DIR}/Dockerfile.${libc_impl}" \
+            --build-arg CURL_VERSION=${CURL_VERSION} "${SRC_DIR}" -o - \
+      | tar -xOf - src/aws-lambda-runtime-interface-client.so > "${artifact}"
+  else
+      echo "multi-arch not requested, assuming this is a workaround to goofyness when docker buildx is enabled on Linux CI environments."
+      echo "enabling docker buildx often updates the docker api version, so assuming that docker cli is also too old to use --output type=tar, so doing alternative build-tag-run approach"
+      image_name="lambda-java-jni-lib-${libc_impl}-${arch}"
+      docker build --platform="${docker_platform}" \
+            -t "${image_name}" \
+            -f "${SRC_DIR}/Dockerfile.${libc_impl}" \
+            --build-arg CURL_VERSION=${CURL_VERSION} "${SRC_DIR}"
+
+      docker run --rm --entrypoint /bin/cat "${image_name}" \
+            /src/aws-lambda-runtime-interface-client.so > "${artifact}"
+  fi
+
+  [ -f "${artifact}" ]
+
+  # file -b ${artifact} produces lines like this:
+  #     x86_64:  ELF 64-bit LSB shared object, x86-64, version 1 (GNU/Linux), dynamically linked, BuildID[sha1]=582888b42da34895828e1281cbbae15d279175b7, not stripped
+  #   aarch_64:  ELF 64-bit LSB shared object, ARM aarch64, version 1 (GNU/Linux), dynamically linked, BuildID[sha1]=fa54218974fb2c17772b6acf22467a2c67a87011, not stripped
+  # we need to ensure it has the expected architecture in it
+  #
+  # cut -d "," -f2 will extract second field (' x86-64' or ' ARM aarch64')
+  # tr -d '-' removes '-', so we'll have (' x8664' or ' ARM aarch64')
+  # grep -q is for quiet mode, no output
+  # ${arch//_} removes '_' chars from the `aarch` variable, (aarch_64 => aarch64, x86_64 => x8664)
+  if ! file -b "${artifact}" | cut -d "," -f2 | tr -d '-' | grep -q "${arch//_}"; then
+      echo "${artifact} did not appear to be the correct architecture, check that Docker buildx is enabled"
+      exit 1
+  fi
+}
+
+function get_target_artifact() {
+  target_os=$1
+  target_arch=$2
+
+  target_file="${DST_DIR}/classes/jni/libaws-lambda-jni.${target_os}-${target_arch}.so"
+  target_dir=$(dirname "$target_file")
+  mkdir -p "$target_dir"
+  echo "$target_file"
+}
+
+
+
+if [ -n "$BUILD_OS" ] && [ -n "$BUILD_ARCH" ]; then
+  # build for the specified arch and libc implementation
+  libc_impl="glibc"
+  if [ "$BUILD_OS" == "linux_musl" ]; then
+    libc_impl="musl"
+  fi
+  target_artifact=$(get_target_artifact "$BUILD_OS" "$BUILD_ARCH")
+  build_for_libc_arch "$libc_impl" "$BUILD_ARCH" "$target_artifact"
+else
+  # build for all architectures and libc implementations
+  declare -a ARCHITECTURES=("x86_64" "aarch_64")
+  declare -a LIBC_IMPLS=("glibc" "musl")
+
+  for arch in "${ARCHITECTURES[@]}"; do
+
+      if [[ "${MULTI_ARCH}" != "true" ]] && [[ "$(arch)" != "${arch}" ]]; then
+          echo "multi arch build not requested and host arch is $(arch), so skipping ${arch}..."
+          continue
+      fi
+
+      for libc_impl in "${LIBC_IMPLS[@]}"; do
+        target_os=$(get_target_os $libc_impl)
+        target_artifact=$(get_target_artifact "$target_os" "$arch")
+        build_for_libc_arch "$libc_impl" "$arch" "$target_artifact"
+      done
+
+  done
+fi

--- a/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/EventHandlerLoaderTest.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/EventHandlerLoaderTest.java
@@ -1,0 +1,77 @@
+package com.amazonaws.services.lambda.runtime.api.client;
+
+import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.InvocationRequest;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EventHandlerLoaderTest {
+
+    @Test
+    void RequestHandlerTest() throws Exception {
+        String handler = "test.lambda.handlers.RequestHandlerImpl";
+        LambdaRequestHandler lambdaRequestHandler = getLambdaRequestHandler(handler);
+        assertSuccessfulInvocation(lambdaRequestHandler);
+    }
+
+    @Test
+    void RequestStreamHandlerTest() throws Exception {
+        String handler = "test.lambda.handlers.RequestStreamHandlerImpl";
+        LambdaRequestHandler lambdaRequestHandler = getLambdaRequestHandler(handler);
+        assertSuccessfulInvocation(lambdaRequestHandler);
+    }
+
+    @Test
+    void PojoHandlerTest_noParams() throws Exception {
+        String handler = "test.lambda.handlers.POJOHanlderImpl::noParamsHandler";
+        LambdaRequestHandler lambdaRequestHandler = getLambdaRequestHandler(handler);
+        assertSuccessfulInvocation(lambdaRequestHandler);
+    }
+
+    @Test
+    void PojoHandlerTest_oneParamEvent() throws Exception {
+        String handler = "test.lambda.handlers.POJOHanlderImpl::oneParamHandler_event";
+        LambdaRequestHandler lambdaRequestHandler = getLambdaRequestHandler(handler);
+        assertSuccessfulInvocation(lambdaRequestHandler);
+    }
+
+
+    @Test
+    void PojoHandlerTest_oneParamContext() throws Exception {
+        String handler = "test.lambda.handlers.POJOHanlderImpl::oneParamHandler_context";
+        LambdaRequestHandler lambdaRequestHandler = getLambdaRequestHandler(handler);
+        assertSuccessfulInvocation(lambdaRequestHandler);
+    }
+
+    @Test
+    void PojoHandlerTest_twoParams() throws Exception {
+        String handler = "test.lambda.handlers.POJOHanlderImpl::twoParamsHandler";
+        LambdaRequestHandler lambdaRequestHandler = getLambdaRequestHandler(handler);
+        assertSuccessfulInvocation(lambdaRequestHandler);
+    }
+
+    private LambdaRequestHandler getLambdaRequestHandler(String handler) throws ClassNotFoundException {
+        ClassLoader cl = this.getClass().getClassLoader();
+        HandlerInfo handlerInfo = HandlerInfo.fromString(handler, cl);
+        return EventHandlerLoader.loadEventHandler(handlerInfo);
+    }
+
+    private static void assertSuccessfulInvocation(LambdaRequestHandler lambdaRequestHandler) throws Exception {
+        InvocationRequest invocationRequest = getTestInvocationRequest();
+
+        ByteArrayOutputStream resultBytes = lambdaRequestHandler.call(invocationRequest);
+        String result = resultBytes.toString();
+
+        assertEquals("\"success\"", result);
+    }
+
+    private static InvocationRequest getTestInvocationRequest() {
+        InvocationRequest invocationRequest = new InvocationRequest();
+        invocationRequest.setContent("\"Hello\"".getBytes());
+        invocationRequest.setId("id");
+        invocationRequest.setXrayTraceId("traceId");
+        return invocationRequest;
+    }
+}

--- a/aws-lambda-java-runtime-interface-client/src/test/java/test/lambda/handlers/POJOHanlderImpl.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/test/lambda/handlers/POJOHanlderImpl.java
@@ -1,0 +1,26 @@
+package test.lambda.handlers;
+
+import com.amazonaws.services.lambda.runtime.Context;
+
+@SuppressWarnings("unused")
+public class POJOHanlderImpl {
+    @SuppressWarnings("unused")
+    public String noParamsHandler() {
+        return "success";
+    }
+
+    @SuppressWarnings("unused")
+    public String oneParamHandler_event(String event) {
+        return "success";
+    }
+
+    @SuppressWarnings("unused")
+    public String oneParamHandler_context(Context context) {
+        return "success";
+    }
+
+    @SuppressWarnings("unused")
+    public String twoParamsHandler(String event, Context context) {
+        return "success";
+    }
+}

--- a/aws-lambda-java-runtime-interface-client/src/test/java/test/lambda/handlers/RequestHandlerImpl.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/test/lambda/handlers/RequestHandlerImpl.java
@@ -1,0 +1,12 @@
+package test.lambda.handlers;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+
+public class RequestHandlerImpl implements RequestHandler<String, String> {
+    @Override
+    public String handleRequest(String event, Context context) {
+        return "success";
+    }
+}

--- a/aws-lambda-java-runtime-interface-client/src/test/java/test/lambda/handlers/RequestStreamHandlerImpl.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/test/lambda/handlers/RequestStreamHandlerImpl.java
@@ -1,0 +1,16 @@
+package test.lambda.handlers;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+@SuppressWarnings("unused")
+public class RequestStreamHandlerImpl implements RequestStreamHandler {
+    @Override
+    public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
+        output.write("\"success\"".getBytes());
+    }
+}


### PR DESCRIPTION
*Description of changes:* Prepare platform specific artifacts. After this change, the following jar files will be prepared as part of the build:
```
-rw-r--r--  1 smirnoal  user   1.1M 17 Jul 13:20 target/aws-lambda-java-runtime-interface-client-2.3.2-linux-aarch_64.jar
-rw-r--r--  1 smirnoal  user   1.1M 17 Jul 13:19 target/aws-lambda-java-runtime-interface-client-2.3.2- linux-x86_64.jar
-rw-r--r--  1 smirnoal  user   839K 17 Jul 13:20 target/aws-lambda-java-runtime-interface-client-2.3.2-linux_musl-aarch_64.jar
-rw-r--r--  1 smirnoal  user   850K 17 Jul 13:19 target/aws-lambda-java-runtime-interface-client-2.3.2-linux_musl-x86_64.jar
-rw-r--r--  1 smirnoal  user   2.2M 17 Jul 13:19 target/aws-lambda-java-runtime-interface-client-2.3.2.jar
```
Also, a new system property was introduced to avoid writing .so files to a temporary location: `com.amazonaws.services.lambda.runtime.api.client.runtimeapi.NativeClient.JNI`. A JNI library can be extracted somewhere during build time and then the location can be specified with this system property

*Target (OCI, Managed Runtime, both):* both


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
