### PR TITLE
Stage release 2.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The purpose of this package is to allow developers to deploy their applications 
 <dependency>
  <groupId>com.amazonaws</groupId>
  <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
- <version>2.3.2</version>
+ <version>2.3.3</version>
 </dependency>
 ```
 

--- a/aws-lambda-java-runtime-interface-client/README.md
+++ b/aws-lambda-java-runtime-interface-client/README.md
@@ -70,7 +70,7 @@ pom.xml
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-      <version>2.3.2</version>
+      <version>2.3.3</version>
     </dependency>
   </dependencies>
   <build>
@@ -160,7 +160,7 @@ platform-specific JAR by setting the `<classifier>`.
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-    <version>2.3.2</version>
+    <version>2.3.3</version>
     <classifier>linux-x86_64</classifier>
 </dependency>
 ```

--- a/aws-lambda-java-runtime-interface-client/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-runtime-interface-client/RELEASE.CHANGELOG.md
@@ -1,3 +1,8 @@
+### July 17, 2023
+`2.3.3`
+- Build platform specific JAR files
+- NativeClient optimisations
+
 ### April 14, 2023
 `2.3.2`
 - Add curl patch

--- a/aws-lambda-java-runtime-interface-client/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-    <version>2.3.2</version>
+    <version>2.3.3</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Runtime Interface Client</name>

--- a/aws-lambda-java-runtime-interface-client/test/integration/test-handler/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/test-handler/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-            <version>2.3.2</version>
+            <version>2.3.3</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
*Description of changes:* Release new version of Runtime interface client - 2.3.3
This release includes building platform/arch specific artefacts and NativeClient optimisations

*Target (OCI, Managed Runtime, both):* both


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
