### PR TITLE
[alc] fix nullpointer exception when logging null (#38)

### DIFF
--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/logging/AbstractLambdaLogger.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/logging/AbstractLambdaLogger.java
@@ -33,7 +33,8 @@ public abstract class AbstractLambdaLogger implements LambdaLogger {
     protected abstract void logMessage(byte[] message, LogLevel logLevel);
 
     protected void logMessage(String message, LogLevel logLevel) {
-        logMessage(message.getBytes(UTF_8), logLevel);
+        byte[] messageBytes = message == null ? null : message.getBytes(UTF_8);
+        logMessage(messageBytes, logLevel);
     }
 
     @Override


### PR DESCRIPTION
*Description of changes:*
Integration tests highlighted a problem, when logging a `null` object the runtime crashed with `NullPointerException`.

With this fix either the log formatter will handle the `null` value, or the `ContextLogger` when no formatting is involved, `AbstractLogger` will just pass it.

*Target (OCI, Managed Runtime, both):* both

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
