### PR TITLE
Add support for events v4

### DIFF
--- a/aws-lambda-java-serialization/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-serialization/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### September 21, 2023
+`1.1.3`:
+- Add support for event v4 lib
+
 ### February 22, 2023
 `1.1.1`:
 - Register `JodaModule` to JacksonFactory

--- a/aws-lambda-java-serialization/pom.xml
+++ b/aws-lambda-java-serialization/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-serialization</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Runtime Serialization</name>
@@ -211,6 +211,27 @@
                                 <relocation>
                                     <pattern>com.fasterxml.jackson</pattern>
                                     <shadedPattern>${relocation.prefix}.com.fasterxml.jackson</shadedPattern>
+                                    <excludes>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonInclude</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonInclude$Value</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonInclude$Include</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonProperty</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonProperty$Access</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonFormat</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonFormat$Shape</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonFormat$Feature</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonIgnore</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonSerialize</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonView</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonTypeInfo</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonRawValue</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonUnwrapped</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonBackReference</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JsonManagedReference</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JacksonAnnotation</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.JacksonAnnotationValue</exclude>
+                                        <exclude>com.fasterxml.jackson.annotation.OptBoolean</exclude>
+                                    </excludes>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.google.gson</pattern>

--- a/aws-lambda-java-serialization/verify-relocation.sh
+++ b/aws-lambda-java-serialization/verify-relocation.sh
@@ -19,7 +19,7 @@ if [[ ! -z "$OUTPUT" ]]; then
 fi
 
 echo 'Validating that everything other than serialization module classes were relocated'
-OUTPUT=$(zipinfo ${ARTIFACT_PATH} | grep '.class' | grep -v ${SERIALIZATION_MODULE_PATTERN//.//} | grep -v 'META-INF' | grep -v ${RELOCATION_PREFIX//.//} || true)
+OUTPUT=$(zipinfo ${ARTIFACT_PATH} | grep '.class' | grep -v ${SERIALIZATION_MODULE_PATTERN//.//} | grep -v 'com.fasterxml.jackson.annotation' | grep -v 'META-INF' | grep -v ${RELOCATION_PREFIX//.//} || true)
 if [[ ! -z "$OUTPUT" ]]; then
     echo "Some classes were not relocated"
     echo ${OUTPUT}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Currently events v4 are not supporting, because of maven shade plugin relocate whole com.fasterxml.jackson package.
At this pull request I am excluding Jackson annotations interfaces(with minimal change risk). It will enable support Events v4 lib

Target (OCI, Managed Runtime, both):
both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.