### PR TITLE
Added missing 'version' field to APIGatewayProxyRequestEvent

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayProxyRequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/apigateway/APIGatewayProxyRequestEvent.java
@@ -34,7 +34,7 @@ import java.util.Map;
 public class APIGatewayProxyRequestEvent implements Serializable, HttpRequestEvent {
 
     private static final long serialVersionUID = 4189228800688527467L;
-
+    private String version;
     private String resource;
     private String path;
     private String httpMethod;

--- a/aws-lambda-java-events/src/test/resources/event_models/api_gateway_proxy_request_event.json
+++ b/aws-lambda-java-events/src/test/resources/event_models/api_gateway_proxy_request_event.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0",
   "path": "/test/hello",
   "headers": {
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The "version" field is missing in APIGatewayProxyRequestEvent based on the official [documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format).

*Target (OCI, Managed Runtime, both):*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
