### PR TITLE
Change AwsProxyResponseEvent's isBase64Encoded field to boolean primitive type to avoid NullPointer…

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/AwsProxyResponseEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/AwsProxyResponseEvent.java
@@ -29,5 +29,5 @@ public class AwsProxyResponseEvent {
 
     private String body;
 
-    private Boolean isBase64Encoded;
+    private boolean isBase64Encoded;
 }


### PR DESCRIPTION
…Exception

*Issue #, if available:*

*Description of changes:*

Change AwsProxyResponseEvent's isBase64Encoded field to boolean primitive type to avoid NullPointer

*Target (OCI, Managed Runtime, both):*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
