### PR TITLE
Stage aws-lambda-java-serialization 1.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ This package defines the Lambda serialization logic using in the `aws-lambda-jav
 <dependency>
  <groupId>com.amazonaws</groupId>
  <artifactId>aws-lambda-java-serialization</artifactId>
- <version>1.0.1</version>
+ <version>1.1.4</version>
 </dependency>
 ```
 

--- a/aws-lambda-java-serialization/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-serialization/RELEASE.CHANGELOG.md
@@ -1,3 +1,8 @@
+### October 19, 2023
+`1.1.4`:
+- Update org.json version to 20231013
+- Rollback relocation changes(1.1.3 version)
+
 ### September 21, 2023
 `1.1.3`:
 - Add support for event v4 lib

--- a/aws-lambda-java-serialization/pom.xml
+++ b/aws-lambda-java-serialization/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-serialization</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Runtime Serialization</name>
@@ -34,7 +34,7 @@
         <relocation.prefix>com.amazonaws.lambda.thirdparty</relocation.prefix>
         <jackson.version>2.14.2</jackson.version>
         <gson.version>2.10.1</gson.version>
-        <json.version>20230227</json.version>
+        <json.version>20231013</json.version>
         <owasp.version>7.3.2</owasp.version>
     </properties>
 
@@ -211,27 +211,6 @@
                                 <relocation>
                                     <pattern>com.fasterxml.jackson</pattern>
                                     <shadedPattern>${relocation.prefix}.com.fasterxml.jackson</shadedPattern>
-                                    <excludes>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonInclude</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonInclude$Value</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonInclude$Include</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonProperty</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonProperty$Access</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonFormat</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonFormat$Shape</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonFormat$Feature</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonIgnore</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonSerialize</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonView</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonTypeInfo</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonRawValue</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonUnwrapped</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonBackReference</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JsonManagedReference</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JacksonAnnotation</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.JacksonAnnotationValue</exclude>
-                                        <exclude>com.fasterxml.jackson.annotation.OptBoolean</exclude>
-                                    </excludes>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.google.gson</pattern>

--- a/aws-lambda-java-serialization/verify-relocation.sh
+++ b/aws-lambda-java-serialization/verify-relocation.sh
@@ -19,7 +19,7 @@ if [[ ! -z "$OUTPUT" ]]; then
 fi
 
 echo 'Validating that everything other than serialization module classes were relocated'
-OUTPUT=$(zipinfo ${ARTIFACT_PATH} | grep '.class' | grep -v ${SERIALIZATION_MODULE_PATTERN//.//} | grep -v 'com.fasterxml.jackson.annotation' | grep -v 'META-INF' | grep -v ${RELOCATION_PREFIX//.//} || true)
+OUTPUT=$(zipinfo ${ARTIFACT_PATH} | grep '.class' | grep -v ${SERIALIZATION_MODULE_PATTERN//.//} | grep -v 'META-INF' | grep -v ${RELOCATION_PREFIX//.//} || true)
 if [[ ! -z "$OUTPUT" ]]; then
     echo "Some classes were not relocated"
     echo ${OUTPUT}

--- a/aws-lambda-java-tests/pom.xml
+++ b/aws-lambda-java-tests/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-serialization</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.4</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lambda-java-libs/issues/448

*Description of changes:*  Stage version 1.1.4:
- Update org.json version to 20231013
- Rollback relocation changes

*Target (OCI, Managed Runtime, both):* both


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
