### PR TITLE
change scope for jetbrains annotations to provided

### DIFF
--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -61,6 +61,7 @@
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>24.0.1</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
*Description of changes:*
We should avoid we introduce a particular annotation library into the dependency of users of the library. There are a lot of libraries out there and users may have a different preference. I've changed the scope to provided according to the docs https://github.com/JetBrains/java-annotations#using-the-annotations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
