### PR TITLE
update ConnectEvent Queue definition

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ConnectEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ConnectEvent.java
@@ -20,6 +20,8 @@ import lombok.NoArgsConstructor;
 import java.io.Serializable;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Class to represent an Amazon Connect contact flow event.
  *
@@ -59,8 +61,32 @@ public class ConnectEvent implements Serializable, Cloneable {
         private String initiationMethod;
         private String instanceArn;
         private String previousContactId;
-        private String queue;
+        private Queue queue;
         private SystemEndpoint systemEndpoint;
+    }
+
+    @Data
+    @Builder(setterPrefix = "with")
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Queue implements Serializable, Cloneable {
+        @JsonProperty(value = "ARN")
+        private String arn;
+        @JsonProperty(value = "Name")
+        private String name;
+        @JsonProperty(value = "OutboundCallerId")
+        private OutboundCallerId outboundCallerId;
+    }
+
+    @Data
+    @Builder(setterPrefix = "with")
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OutboundCallerId implements Serializable, Cloneable {
+        @JsonProperty(value = "Address")
+        private String address;
+        @JsonProperty(value = "Type")
+        private String type;
     }
 
     @Data


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update ConnectEvent Queue definition. According to Amazon Connect latest doc: https://docs.aws.amazon.com/connect/latest/adminguide/connect-lambda-functions.html#function-contact-flow, Queue is an Object. Current type definition is String, which causes parsing error

``` 
Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
 at [Source: (ByteArrayInputStream); line: 1, column: 580] (through reference chain: com.amazonaws.services.lambda.runtime.events.ConnectEvent["Details"]->com.amazonaws.services.lambda.runtime.events.ConnectEvent$Details["ContactData"]->com.amazonaws.services.lambda.runtime.events.ConnectEvent$ContactData["Queue"])
```

*Target (OCI, Managed Runtime, both):Managed Runtime


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
