### PR TITLE
update ConnectEvent queue definition

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ConnectEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ConnectEvent.java
@@ -90,10 +90,35 @@ public class ConnectEvent implements Serializable {
         private String previousContactId;
 
         @JsonProperty("Queue")
-        private String queue;
+        private Queue queue;
 
         @JsonProperty("SystemEndpoint")
         private SystemEndpoint systemEndpoint;
+    }
+
+
+    @Data
+    @Builder(setterPrefix = "with")
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Queue implements Serializable {
+        @JsonProperty("ARN")
+        private String arn;
+        @JsonProperty("Name")
+        private String name;
+        @JsonProperty("OutboundCallerId")
+        private OutboundCallerId outboundCallerId;
+    }
+
+    @Data
+    @Builder(setterPrefix = "with")
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OutboundCallerId implements Serializable {
+        @JsonProperty("Address")
+        private String address;
+        @JsonProperty("Type")
+        private String type;
     }
 
     @Data

--- a/aws-lambda-java-events/src/test/resources/event_models/connect_event.json
+++ b/aws-lambda-java-events/src/test/resources/event_models/connect_event.json
@@ -22,7 +22,14 @@
         }
       },
       "PreviousContactId": "4a573372-1f28-4e26-b97b-XXXXXXXXXXX",
-      "Queue": "QueueName",
+      "Queue": {
+        "ARN": "arn:aws:connect:eu-west-2:111111111111:instance/cccccccc-bbbb-dddd-eeee-ffffffffffff/queue/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "Name": "PasswordReset",
+        "OutboundCallerId": {
+          "Address": "+12345678903",
+          "Type": "TELEPHONE_NUMBER"
+        }
+      },
       "SystemEndpoint": {
         "Address": "+1234567890",
         "Type": "TELEPHONE_NUMBER"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update ConnectEvent Queue definition. According to Amazon Connect latest doc: https://docs.aws.amazon.com/connect/latest/adminguide/connect-lambda-functions.html#function-contact-flow, Queue is an Object. Current type definition is String, which causes parsing error

```Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
 at [Source: (ByteArrayInputStream); line: 1, column: 580] (through reference chain: com.amazonaws.services.lambda.runtime.events.ConnectEvent["Details"]->com.amazonaws.services.lambda.runtime.events.ConnectEvent$Details["ContactData"]->com.amazonaws.services.lambda.runtime.events.ConnectEvent$ContactData["Queue"])```

*Target (OCI, Managed Runtime, both):*Managed Runtime


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
