### PR TITLE
Stage aws-lambda-java-serialization 1.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ This package defines the Lambda serialization logic using in the `aws-lambda-jav
 <dependency>
  <groupId>com.amazonaws</groupId>
  <artifactId>aws-lambda-java-serialization</artifactId>
- <version>1.1.4</version>
+ <version>1.1.5</version>
 </dependency>
 ```
 

--- a/aws-lambda-java-serialization/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-serialization/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### December 1, 2023
+`1.1.5`:
+- Add support for DynamodbEvent.DynamodbStreamRecord serialization
+
 ### October 19, 2023
 `1.1.4`:
 - Update org.json version to 20231013

--- a/aws-lambda-java-serialization/pom.xml
+++ b/aws-lambda-java-serialization/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-serialization</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Runtime Serialization</name>

--- a/aws-lambda-java-tests/pom.xml
+++ b/aws-lambda-java-tests/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-serialization</artifactId>
-            <version>1.1.4</version>
+            <version>1.1.5</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
*Description of changes:* Stage new version of aws-lambda-java-serialization

*Changelog:* Add support for DynamodbEvent.DynamodbStreamRecord serialization

*Target (OCI, Managed Runtime, both):* both


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
