### PR TITLE
Stage aws-lambda-java-events 3.11.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ public class SqsHandler implements RequestHandler<SQSEvent, String> {
 <dependency>
  <groupId>com.amazonaws</groupId>
  <artifactId>aws-lambda-java-events</artifactId>
- <version>3.11.3</version>
+ <version>3.11.4</version>
 </dependency>
 ```
 

--- a/aws-lambda-java-events/README.md
+++ b/aws-lambda-java-events/README.md
@@ -69,7 +69,7 @@
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.11.3</version>
+        <version>3.11.4</version>
     </dependency>
     ...
 </dependencies>

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,3 +1,8 @@
+### December 1, 2023
+`3.11.4`:
+- Improve `toString` in Cognito events by calling `super`
+- Added missing `version` field to ScheduledEvent from CloudWatch
+
 ### September 1, 2023
 `3.11.3`:
 - Update challengeAnswer field format in CognitoUserPoolEvent 

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-events</artifactId>
-    <version>3.11.3</version>
+    <version>3.11.4</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Events Library</name>

--- a/aws-lambda-java-tests/pom.xml
+++ b/aws-lambda-java-tests/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.11.3</version>
+            <version>3.11.4</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/samples/kinesis-firehose-event-handler/pom.xml
+++ b/samples/kinesis-firehose-event-handler/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.11.3</version>
+            <version>3.11.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
*Description of changes:*
- Improve `toString` in Cognito events by calling `super`
- Added missing `version` field to ScheduledEvent from CloudWatch

*Target (OCI, Managed Runtime, both):* both


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
