### PR TITLE
Added missing Identity fields in VpcLatticeV2RequestEvent

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/VpcLatticeV2RequestEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/VpcLatticeV2RequestEvent.java
@@ -83,5 +83,9 @@ public class VpcLatticeV2RequestEvent implements HttpRequestEvent {
         private String principal;
         private String sessionName;
         private String x509SanDns;
+        private String x509SanNameCn;
+        private String x509SubjectCn;
+        private String x509IssuerOu;
+        private String x509SanUri;
     }
 }


### PR DESCRIPTION




*Issue #, if available:*

*Description of changes:*

Added missing Identity fields in VpcLatticeV2RequestEvent
See: https://docs.aws.amazon.com/vpc-lattice/latest/ug/lambda-functions.html#receive-event-from-service

*Target (OCI, Managed Runtime, both):*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
