### PR TITLE
Fixing Queue representation in ConnectEvent.java

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ConnectEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/ConnectEvent.java
@@ -59,7 +59,7 @@ public class ConnectEvent implements Serializable, Cloneable {
         private String initiationMethod;
         private String instanceArn;
         private String previousContactId;
-        private String queue;
+        private Queue queue;
         private SystemEndpoint systemEndpoint;
     }
 
@@ -72,6 +72,15 @@ public class ConnectEvent implements Serializable, Cloneable {
         private String type;
     }
 
+    @Data
+    @Builder(setterPrefix = "with")
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Queue implements Serializable, Cloneable {
+        private String name;
+        private String arn;
+    }
+    
     @Data
     @Builder(setterPrefix = "with")
     @NoArgsConstructor


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
At present, when trying to invoke a lambda that uses a ConnectEvent in its handler, it will fail with:
```
An error occurred during JSON parsing: java.lang.RuntimeException
java.lang.RuntimeException: An error occurred during JSON parsing
Caused by: java.io.UncheckedIOException: com.amazonaws.lambda.thirdparty.com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
 at [Source: (ByteArrayInputStream); line: 1, column: 581] (through reference chain: com.amazonaws.services.lambda.runtime.events.ConnectEvent["Details"]->com.amazonaws.services.lambda.runtime.events.ConnectEvent$Details["ContactData"]->com.amazonaws.services.lambda.runtime.events.ConnectEvent$ContactData["Queue"])
```

I am fixing the Event model so that it can be correctly deserialised.

AWS Connect defines the Queue as an object when invoking a lambda, not a string. The object contains ARN and Name (as well as Address and Type). See here for the full model:
https://docs.aws.amazon.com/connect/latest/adminguide/connect-lambda-functions.html

For reference, I have followed the model used by the Go implementation here: https://github.com/aws/aws-lambda-go/blame/main/events/connect.go

*Target (OCI, Managed Runtime, both):*
both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
