### PR TITLE
Add S3BatchEventV2

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/S3BatchEventV2.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/S3BatchEventV2.java
@@ -1,0 +1,50 @@
+package com.amazonaws.services.lambda.runtime.events;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Event to represent the payload which is sent to Lambda by S3 Batch to perform a custom
+ * action when using invocation schema version 2.0.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-invoke-lambda.html
+ */
+
+@Data
+@Builder(setterPrefix = "with")
+@NoArgsConstructor
+@AllArgsConstructor
+public class S3BatchEventV2 {
+
+    private String invocationSchemaVersion;
+    private String invocationId;
+    private Job job;
+    private List<Task> tasks;
+
+    @Data
+    @Builder(setterPrefix = "with")
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Job {
+
+        private String id;
+        private Map<String, String> userArguments;
+    }
+
+    @Data
+    @Builder(setterPrefix = "with")
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Task {
+
+        private String taskId;
+        private String s3Key;
+        private String s3VersionId;
+        private String s3BucketName;
+    }
+}

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/S3BatchResponse.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/S3BatchResponse.java
@@ -62,4 +62,10 @@ public class S3BatchResponse {
                 .withInvocationId(s3BatchEvent.getInvocationId())
                 .withInvocationSchemaVersion(s3BatchEvent.getInvocationSchemaVersion());
     }
+
+    public static S3BatchResponseBuilder fromS3BatchEvent(S3BatchEventV2 s3BatchEvent) {
+        return S3BatchResponse.builder()
+                .withInvocationId(s3BatchEvent.getInvocationId())
+                .withInvocationSchemaVersion(s3BatchEvent.getInvocationSchemaVersion());
+    }
 }

--- a/aws-lambda-java-tests/src/main/java/com/amazonaws/services/lambda/runtime/tests/EventLoader.java
+++ b/aws-lambda-java-tests/src/main/java/com/amazonaws/services/lambda/runtime/tests/EventLoader.java
@@ -105,6 +105,10 @@ public class EventLoader {
         return loadEvent(filename, S3Event.class);
     }
 
+    public static S3BatchEventV2 loadS3BatchEventV2(String filename) {
+        return loadEvent(filename, S3BatchEventV2.class);
+    }
+
     public static SecretsManagerRotationEvent loadSecretsManagerRotationEvent(String filename) {
         return loadEvent(filename, SecretsManagerRotationEvent.class);
     }

--- a/aws-lambda-java-tests/src/test/java/com/amazonaws/services/lambda/runtime/tests/S3BatchEventV2Test.java
+++ b/aws-lambda-java-tests/src/test/java/com/amazonaws/services/lambda/runtime/tests/S3BatchEventV2Test.java
@@ -1,0 +1,20 @@
+package com.amazonaws.services.lambda.runtime.tests;
+
+import com.amazonaws.services.lambda.runtime.events.S3BatchEventV2;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class S3BatchEventV2Test {
+
+    @Test
+    public void testS3BatchEventV2() {
+        S3BatchEventV2 event = EventLoader.loadS3BatchEventV2("s3_batch_event_v2.json");
+        assertThat(event).isNotNull();
+        assertThat(event.getInvocationId()).isEqualTo("Jr3s8KZqYWRmaiBhc2RmdW9hZHNmZGpmaGFzbGtkaGZzatx7Ruy");
+        assertThat(event.getJob()).isNotNull();
+        assertThat(event.getJob().getUserArguments().get("MyDestinationBucket")).isEqualTo("destination-directory-bucket-name");
+        assertThat(event.getTasks()).hasSize(1);
+        assertThat(event.getTasks().get(0).getS3Key()).isEqualTo("s3objectkey");
+    }
+}

--- a/aws-lambda-java-tests/src/test/resources/s3_batch_event_v2.json
+++ b/aws-lambda-java-tests/src/test/resources/s3_batch_event_v2.json
@@ -1,0 +1,21 @@
+{
+  "invocationSchemaVersion": "2.0",
+  "invocationId": "Jr3s8KZqYWRmaiBhc2RmdW9hZHNmZGpmaGFzbGtkaGZzatx7Ruy",
+  "job": {
+    "id": "ry77cd60-61f6-4a2b-8a21-d07600c874gf",
+    "userArguments": {
+      "MyDestinationBucket": "destination-directory-bucket-name",
+      "MyDestinationBucketRegion": "us-east-1",
+      "MyDestinationPrefix": "copied/",
+      "MyDestinationObjectKeySuffix": "_new_suffix"
+    }
+  },
+  "tasks": [
+    {
+      "taskId": "y5R3a2lkZ29lc2hlurcS",
+      "s3Key": "s3objectkey",
+      "s3VersionId": null,
+      "s3Bucket": "source-directory-bucket-name"
+    }
+  ]
+}


### PR DESCRIPTION
*Issue  #495*

*Description of changes:*

Add a new S3BatchEventV2 class representing an Event coming from S3 when using invocation schema version 2.
Compared to the other version, it adds the user arguments and changes the bucket ARN to the name.

*Target (OCI, Managed Runtime, both):*
Unsure yet

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
