### PR TITLE
fix: make initializeClient a pure function

### DIFF
--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/LambdaRuntimeApiClientImpl.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/LambdaRuntimeApiClientImpl.java
@@ -38,7 +38,7 @@ public class LambdaRuntimeApiClientImpl implements LambdaRuntimeApiClient {
         Objects.requireNonNull(hostnameAndPort, "hostnameAndPort cannot be null");
         this.baseUrl = "http://" + hostnameAndPort;
         this.invocationEndpoint = this.baseUrl + "/2018-06-01/runtime/invocation/";
-        NativeClient.init();
+        NativeClient.init(hostnameAndPort);
     }
 
     @Override

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/NativeClient.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/NativeClient.java
@@ -14,12 +14,12 @@ import static com.amazonaws.services.lambda.runtime.api.client.runtimeapi.Lambda
  * interactions with the Runtime API.
  */
 class NativeClient {
-    static void init() {
+    static void init(String awsLambdaRuntimeApi) {
         JniHelper.load();
-        initializeClient(USER_AGENT.getBytes());
+        initializeClient(USER_AGENT.getBytes(), awsLambdaRuntimeApi.getBytes());
     }
     
-    static native void initializeClient(byte[] userAgent);
+    static native void initializeClient(byte[] userAgent, byte[] awsLambdaRuntimeApi);
 
     static native InvocationRequest next();
 

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/com_amazonaws_services_lambda_runtime_api_client_runtimeapi_NativeClient.cpp
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/com_amazonaws_services_lambda_runtime_api_client_runtimeapi_NativeClient.cpp
@@ -69,9 +69,9 @@ static std::string toNativeString(JNIEnv *env, jbyteArray jArray) {
   return nativeString;
 }
 
-JNIEXPORT void JNICALL Java_com_amazonaws_services_lambda_runtime_api_client_runtimeapi_NativeClient_initializeClient(JNIEnv *env, jobject thisObject, jbyteArray userAgent) {
+JNIEXPORT void JNICALL Java_com_amazonaws_services_lambda_runtime_api_client_runtimeapi_NativeClient_initializeClient(JNIEnv *env, jobject thisObject, jbyteArray userAgent, jbyteArray awsLambdaRuntimeApi) {
   std::string user_agent = toNativeString(env, userAgent);
-  std::string endpoint(getenv("AWS_LAMBDA_RUNTIME_API"));
+  std::string endpoint = toNativeString(env, awsLambdaRuntimeApi);
   CLIENT = new aws::lambda_runtime::runtime(endpoint, user_agent);
 }
 

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/com_amazonaws_services_lambda_runtime_api_client_runtimeapi_NativeClient.h
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/com_amazonaws_services_lambda_runtime_api_client_runtimeapi_NativeClient.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 JNIEXPORT void JNICALL Java_com_amazonaws_services_lambda_runtime_api_client_runtimeapi_NativeClient_initializeClient
-  (JNIEnv *, jobject, jbyteArray);
+  (JNIEnv *, jobject, jbyteArray, jbyteArray);
 
 JNIEXPORT jobject JNICALL Java_com_amazonaws_services_lambda_runtime_api_client_runtimeapi_NativeClient_next
   (JNIEnv *, jobject);


### PR DESCRIPTION
*Description of changes:*
To be able to test this JNI code, and the runtime api lifecycle, this is a required change so we could inject a mock http server.
This PR transforms NativeClient.init in a pure function as well as initializeClient.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
