### PR TITLE
Use Lambda-Runtime-Function-Error-Type for reporting errors in format "Runtime.<Error>"

### DIFF
--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/AWSLambda.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/AWSLambda.java
@@ -12,7 +12,6 @@ import com.amazonaws.services.lambda.runtime.api.client.logging.LambdaContextLog
 import com.amazonaws.services.lambda.runtime.api.client.logging.LogSink;
 import com.amazonaws.services.lambda.runtime.api.client.logging.StdOutLogSink;
 import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.LambdaError;
-import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.LambdaError;
 import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.LambdaRuntimeApiClient;
 import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.LambdaRuntimeApiClientImpl;
 import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.RapidErrorType;

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/AWSLambda.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/AWSLambda.java
@@ -11,14 +11,14 @@ import com.amazonaws.services.lambda.runtime.api.client.logging.FramedTelemetryL
 import com.amazonaws.services.lambda.runtime.api.client.logging.LambdaContextLogger;
 import com.amazonaws.services.lambda.runtime.api.client.logging.LogSink;
 import com.amazonaws.services.lambda.runtime.api.client.logging.StdOutLogSink;
+import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.LambdaError;
+import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.LambdaError;
 import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.LambdaRuntimeApiClient;
 import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.LambdaRuntimeApiClientImpl;
 import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.RapidErrorType;
 import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.converters.LambdaErrorConverter;
 import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.converters.XRayErrorCauseConverter;
 import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.InvocationRequest;
-import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.LambdaError;
-import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.XRayErrorCause;
 import com.amazonaws.services.lambda.runtime.api.client.util.LambdaOutputStream;
 import com.amazonaws.services.lambda.runtime.api.client.util.UnsafeUtil;
 import com.amazonaws.services.lambda.runtime.logging.LogFormat;
@@ -216,8 +216,10 @@ public class AWSLambda {
             requestHandler = findRequestHandler(handler, customerClassLoader);
         } catch (UserFault userFault) {
             lambdaLogger.log(userFault.reportableError(), lambdaLogger.getLogFormat() == LogFormat.JSON ? LogLevel.ERROR : LogLevel.UNDEFINED);
-            LambdaError error = LambdaErrorConverter.fromUserFault(userFault);
-            runtimeClient.reportInitError(error, RapidErrorType.BadFunctionCode);
+            LambdaError error = new LambdaError(
+                    LambdaErrorConverter.fromUserFault(userFault),
+                    RapidErrorType.BadFunctionCode);
+            runtimeClient.reportInitError(error);
             System.exit(1);
             return;
         }
@@ -244,17 +246,20 @@ public class AWSLambda {
                 shouldExit = f.fatal;
                 userFault = f;
                 UserFault.filterStackTrace(f);
-
-                LambdaError error = LambdaErrorConverter.fromUserFault(f);
-                runtimeClient.reportInvocationError(request.getId(), error, RapidErrorType.BadFunctionCode);
+                LambdaError error = new LambdaError(
+                        LambdaErrorConverter.fromUserFault(f),
+                        RapidErrorType.BadFunctionCode);
+                runtimeClient.reportInvocationError(request.getId(), error);
             } catch (Throwable t) {
                 shouldExit = t instanceof VirtualMachineError || t instanceof IOError;
                 UserFault.filterStackTrace(t);
                 userFault = UserFault.makeUserFault(t);
 
-                LambdaError error = LambdaErrorConverter.fromThrowable(t);
-                XRayErrorCause xRayErrorCause = XRayErrorCauseConverter.fromThrowable(t);
-                runtimeClient.reportInvocationError(request.getId(), error, RapidErrorType.UserException, xRayErrorCause);
+                LambdaError error = new LambdaError(
+                        LambdaErrorConverter.fromThrowable(t),
+                        XRayErrorCauseConverter.fromThrowable(t),
+                        RapidErrorType.UserException);
+                runtimeClient.reportInvocationError(request.getId(), error);
             } finally {
                 if (userFault != null) {
                     lambdaLogger.log(userFault.reportableError(), lambdaLogger.getLogFormat() == LogFormat.JSON ? LogLevel.ERROR : LogLevel.UNDEFINED);
@@ -269,16 +274,18 @@ public class AWSLambda {
             runtimeClient.restoreNext();
         } catch (Exception e1) {
             logExceptionCloudWatch(lambdaLogger, e1);
-            LambdaError error = LambdaErrorConverter.fromThrowable(e1);
-            runtimeClient.reportInitError(error, RapidErrorType.BeforeCheckpointError);
+            runtimeClient.reportInitError(new LambdaError(
+                    LambdaErrorConverter.fromThrowable(e1),
+                    RapidErrorType.BeforeCheckpointError));
             System.exit(64);
         }
         try {
             Core.getGlobalContext().afterRestore(null);
         } catch (Exception restoreExc) {
             logExceptionCloudWatch(lambdaLogger, restoreExc);
-            LambdaError error = LambdaErrorConverter.fromThrowable(restoreExc);
-            runtimeClient.reportRestoreError(error, RapidErrorType.AfterRestoreError);
+            runtimeClient.reportRestoreError(new LambdaError(
+                    LambdaErrorConverter.fromThrowable(restoreExc),
+                    RapidErrorType.AfterRestoreError));
             System.exit(64);
         }
     }

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/DtoSerializers.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/DtoSerializers.java
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 package com.amazonaws.services.lambda.runtime.api.client.runtimeapi;
 
-import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.LambdaError;
+import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.ErrorRequest;
 import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.XRayErrorCause;
 import com.amazonaws.services.lambda.runtime.serialization.PojoSerializer;
 import com.amazonaws.services.lambda.runtime.serialization.factories.GsonFactory;
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 public class DtoSerializers {
 
-    public static byte[] serialize(LambdaError error) {
+    public static byte[] serialize(ErrorRequest error) {
         return serialize(error, SingletonHelper.LAMBDA_ERROR_SERIALIZER);
     }
 
@@ -36,7 +36,7 @@ public class DtoSerializers {
      * This way the serializers will be loaded lazily
      */
     private static class SingletonHelper {
-        private static final PojoSerializer<LambdaError> LAMBDA_ERROR_SERIALIZER = GsonFactory.getInstance().getSerializer(LambdaError.class);
+        private static final PojoSerializer<ErrorRequest> LAMBDA_ERROR_SERIALIZER = GsonFactory.getInstance().getSerializer(ErrorRequest.class);
         private static final PojoSerializer<XRayErrorCause> X_RAY_ERROR_CAUSE_SERIALIZER = GsonFactory.getInstance().getSerializer(XRayErrorCause.class);
     }
 }

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/LambdaError.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/LambdaError.java
@@ -1,0 +1,27 @@
+/*
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+package com.amazonaws.services.lambda.runtime.api.client.runtimeapi;
+
+import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.ErrorRequest;
+import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.XRayErrorCause;
+
+public class LambdaError {
+
+    public final ErrorRequest errorRequest;
+
+    public final XRayErrorCause xRayErrorCause;
+
+    public final RapidErrorType errorType;
+
+    public LambdaError(ErrorRequest errorRequest, XRayErrorCause xRayErrorCause, RapidErrorType errorType) {
+        this.errorRequest = errorRequest;
+        this.xRayErrorCause = xRayErrorCause;
+        this.errorType = errorType;
+    }
+
+    public LambdaError(ErrorRequest errorRequest, RapidErrorType errorType) {
+        this(errorRequest, null, errorType);
+    }
+}

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/LambdaRuntimeApiClient.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/LambdaRuntimeApiClient.java
@@ -19,7 +19,7 @@ public interface LambdaRuntimeApiClient {
      * Report Init error
      * @param error error to report
      */
-    void reportInitError(LambdaError error) throws IOException;
+    void reportInitError(LambdaError error, RapidErrorType errorType) throws IOException;
 
     /**
      * Get next invocation
@@ -38,7 +38,7 @@ public interface LambdaRuntimeApiClient {
      * @param requestId request id
      * @param error error to report
      */
-    void reportInvocationError(String requestId, LambdaError error) throws IOException;
+    void reportInvocationError(String requestId, LambdaError error, RapidErrorType errorType) throws IOException;
 
     /**
      * Report invocation error
@@ -46,7 +46,7 @@ public interface LambdaRuntimeApiClient {
      * @param error error to report
      * @param xRayErrorCause X-Ray error cause
      */
-    void reportInvocationError(String requestId, LambdaError error, XRayErrorCause xRayErrorCause) throws IOException;
+    void reportInvocationError(String requestId, LambdaError error, RapidErrorType errorType, XRayErrorCause xRayErrorCause) throws IOException;
 
     /**
      * SnapStart endpoint to report that beforeCheckoint hooks were executed
@@ -57,5 +57,5 @@ public interface LambdaRuntimeApiClient {
      * SnapStart endpoint to report errors during afterRestore hooks execution
      * @param error error to report
      */
-    void reportRestoreError(LambdaError error) throws IOException;
+    void reportRestoreError(LambdaError error, RapidErrorType errorType) throws IOException;
 }

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/LambdaRuntimeApiClient.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/LambdaRuntimeApiClient.java
@@ -5,8 +5,6 @@ SPDX-License-Identifier: Apache-2.0
 package com.amazonaws.services.lambda.runtime.api.client.runtimeapi;
 
 import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.InvocationRequest;
-import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.LambdaError;
-import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.XRayErrorCause;
 import java.io.IOException;
 
 /**
@@ -19,7 +17,7 @@ public interface LambdaRuntimeApiClient {
      * Report Init error
      * @param error error to report
      */
-    void reportInitError(LambdaError error, RapidErrorType errorType) throws IOException;
+    void reportInitError(LambdaError error) throws IOException;
 
     /**
      * Get next invocation
@@ -38,15 +36,7 @@ public interface LambdaRuntimeApiClient {
      * @param requestId request id
      * @param error error to report
      */
-    void reportInvocationError(String requestId, LambdaError error, RapidErrorType errorType) throws IOException;
-
-    /**
-     * Report invocation error
-     * @param requestId request id
-     * @param error error to report
-     * @param xRayErrorCause X-Ray error cause
-     */
-    void reportInvocationError(String requestId, LambdaError error, RapidErrorType errorType, XRayErrorCause xRayErrorCause) throws IOException;
+    void reportInvocationError(String requestId, LambdaError error) throws IOException;
 
     /**
      * SnapStart endpoint to report that beforeCheckoint hooks were executed
@@ -57,5 +47,5 @@ public interface LambdaRuntimeApiClient {
      * SnapStart endpoint to report errors during afterRestore hooks execution
      * @param error error to report
      */
-    void reportRestoreError(LambdaError error, RapidErrorType errorType) throws IOException;
+    void reportRestoreError(LambdaError error) throws IOException;
 }

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/LambdaRuntimeApiClientImpl.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/LambdaRuntimeApiClientImpl.java
@@ -44,9 +44,9 @@ public class LambdaRuntimeApiClientImpl implements LambdaRuntimeApiClient {
     }
 
     @Override
-    public void reportInitError(LambdaError error) throws IOException {
+    public void reportInitError(LambdaError error, RapidErrorType errorType) throws IOException {
         String endpoint = this.baseUrl + "/2018-06-01/runtime/init/error";
-        reportLambdaError(endpoint, error, null);
+        reportLambdaError(endpoint, error, errorType, null);
     }
 
     @Override
@@ -60,14 +60,14 @@ public class LambdaRuntimeApiClientImpl implements LambdaRuntimeApiClient {
     }
 
     @Override
-    public void reportInvocationError(String requestId, LambdaError error) throws IOException {
-        reportInvocationError(requestId, error, null);
+    public void reportInvocationError(String requestId, LambdaError error, RapidErrorType errorType) throws IOException {
+        reportInvocationError(requestId, error, errorType, null);
     }
 
     @Override
-    public void reportInvocationError(String requestId, LambdaError error, XRayErrorCause xRayErrorCause) throws IOException {
+    public void reportInvocationError(String requestId, LambdaError error, RapidErrorType errorType, XRayErrorCause xRayErrorCause) throws IOException {
         String endpoint = invocationEndpoint + requestId + "/error";
-        reportLambdaError(endpoint, error, xRayErrorCause);
+        reportLambdaError(endpoint, error, errorType, xRayErrorCause);
     }
 
     @Override
@@ -80,16 +80,15 @@ public class LambdaRuntimeApiClientImpl implements LambdaRuntimeApiClient {
     }
 
     @Override
-    public void reportRestoreError(LambdaError error) throws IOException {
+    public void reportRestoreError(LambdaError error, RapidErrorType errorType) throws IOException {
         String endpoint = this.baseUrl + "/2018-06-01/runtime/restore/error";
-        reportLambdaError(endpoint, error, null);
+        reportLambdaError(endpoint, error, errorType, null);
     }
 
-    void reportLambdaError(String endpoint, LambdaError error, XRayErrorCause xRayErrorCause) throws IOException {
+    void reportLambdaError(String endpoint, LambdaError error, RapidErrorType errorType, XRayErrorCause xRayErrorCause) throws IOException {
         Map<String, String> headers = new HashMap<>();
-        if (error.errorType != null && !error.errorType.isEmpty()) {
-            headers.put(ERROR_TYPE_HEADER, error.errorType);
-        }
+        headers.put(ERROR_TYPE_HEADER, errorType.getRapidError());
+
         if (xRayErrorCause != null) {
             byte[] xRayErrorCauseJson = DtoSerializers.serialize(xRayErrorCause);
             if (xRayErrorCauseJson != null && xRayErrorCauseJson.length < XRAY_ERROR_CAUSE_MAX_HEADER_SIZE) {

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/RapidErrorType.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/RapidErrorType.java
@@ -1,3 +1,7 @@
+/*
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
 package com.amazonaws.services.lambda.runtime.api.client.runtimeapi;
 
 public enum RapidErrorType {

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/RapidErrorType.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/RapidErrorType.java
@@ -1,0 +1,12 @@
+package com.amazonaws.services.lambda.runtime.api.client.runtimeapi;
+
+public enum RapidErrorType {
+    BadFunctionCode,
+    UserException,
+    BeforeCheckpointError,
+    AfterRestoreError;
+
+    public String getRapidError() {
+        return "Runtime." + this;
+    }
+}

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/converters/LambdaErrorConverter.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/converters/LambdaErrorConverter.java
@@ -5,20 +5,21 @@ SPDX-License-Identifier: Apache-2.0
 package com.amazonaws.services.lambda.runtime.api.client.runtimeapi.converters;
 
 import com.amazonaws.services.lambda.runtime.api.client.UserFault;
-import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.LambdaError;
+import com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.ErrorRequest;
 
 public class LambdaErrorConverter {
     private LambdaErrorConverter() {
     }
 
-    public static LambdaError fromUserFault(UserFault userFault) {
+    public static ErrorRequest fromUserFault(UserFault userFault) {
         // Not setting stacktrace for compatibility with legacy/native runtime
-        return new LambdaError(userFault.msg, userFault.exception, null);
+        return new ErrorRequest(userFault.msg, userFault.exception, null);
     }
 
-    public static LambdaError fromThrowable(Throwable throwable) {
-        String errorMessage = throwable.getLocalizedMessage() == null 
-            ? throwable.getClass().getName() : throwable.getLocalizedMessage();
+    public static ErrorRequest fromThrowable(Throwable throwable) {
+        String errorMessage = throwable.getLocalizedMessage() == null
+            ? throwable.getClass().getName()
+            : throwable.getLocalizedMessage();
         String errorType = throwable.getClass().getName();
 
         StackTraceElement[] trace = throwable.getStackTrace();
@@ -26,6 +27,6 @@ public class LambdaErrorConverter {
         for (int i = 0; i < trace.length; i++) {
             stackTrace[i] = trace[i].toString();
         }
-        return new LambdaError(errorMessage, errorType, stackTrace);
+        return new ErrorRequest(errorMessage, errorType, stackTrace);
     }
 }

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/dto/ErrorRequest.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/dto/ErrorRequest.java
@@ -4,16 +4,16 @@ SPDX-License-Identifier: Apache-2.0
 */
 package com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto;
 
-public class LambdaError {
+public class ErrorRequest {
     public String errorMessage;
     public String errorType;
     public String[] stackTrace;
 
     @SuppressWarnings("unused")
-    public LambdaError() {
+    public ErrorRequest() {
     }
 
-    public LambdaError(String errorMessage, String errorType, String[] stackTrace) {
+    public ErrorRequest(String errorMessage, String errorType, String[] stackTrace) {
         this.errorMessage = errorMessage;
         this.errorType = errorType;
         this.stackTrace = stackTrace;


### PR DESCRIPTION
*Issue #, if available:* integration tests failures 

*Description of changes:* Use "Lambda-Runtime-Function-Error-Type" header to report valid error types to RAPID instead of exception class names.

*Target (OCI, Managed Runtime, both):* both


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
