### PR TITLE
bump: RIC to 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The purpose of this package is to allow developers to deploy their applications 
 <dependency>
  <groupId>com.amazonaws</groupId>
  <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
- <version>2.5.1</version>
+ <version>2.6.0</version>
 </dependency>
 ```
 

--- a/aws-lambda-java-runtime-interface-client/README.md
+++ b/aws-lambda-java-runtime-interface-client/README.md
@@ -70,7 +70,7 @@ pom.xml
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-      <version>2.5.1</version>
+      <version>2.6.0</version>
     </dependency>
   </dependencies>
   <build>
@@ -160,7 +160,7 @@ platform-specific JAR by setting the `<classifier>`.
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-    <version>2.5.1</version>
+    <version>2.6.0</version>
     <classifier>linux-x86_64</classifier>
 </dependency>
 ```

--- a/aws-lambda-java-runtime-interface-client/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-runtime-interface-client/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### August 7, 2024
+`2.6.0`
+- Runtime API client improvements: use Lambda-Runtime-Function-Error-Type for reporting errors in format "Runtime.<Error>" 
+
 ### June 28, 2024
 `2.5.1`
 - Runtime API client improvements: fix a DNS cache issue

--- a/aws-lambda-java-runtime-interface-client/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-    <version>2.5.1</version>
+    <version>2.6.0</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Runtime Interface Client</name>

--- a/aws-lambda-java-runtime-interface-client/test/integration/test-handler/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/test-handler/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
-            <version>2.5.1</version>
+            <version>2.6.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
*Description of changes:*

Bump `aws-lambda-java-runtime-interface-client` to `2.6.0`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
