### PR TITLE
Fix name of s3Bucket field of Task class in S3BatchEventV2

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/S3BatchEventV2.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/S3BatchEventV2.java
@@ -45,6 +45,6 @@ public class S3BatchEventV2 {
         private String taskId;
         private String s3Key;
         private String s3VersionId;
-        private String s3BucketName;
+        private String s3Bucket;
     }
 }

--- a/aws-lambda-java-tests/src/test/java/com/amazonaws/services/lambda/runtime/tests/S3BatchEventV2Test.java
+++ b/aws-lambda-java-tests/src/test/java/com/amazonaws/services/lambda/runtime/tests/S3BatchEventV2Test.java
@@ -16,5 +16,6 @@ public class S3BatchEventV2Test {
         assertThat(event.getJob().getUserArguments().get("MyDestinationBucket")).isEqualTo("destination-directory-bucket-name");
         assertThat(event.getTasks()).hasSize(1);
         assertThat(event.getTasks().get(0).getS3Key()).isEqualTo("s3objectkey");
+        assertThat(event.getTasks().get(0).getS3Bucket()).isEqualTo("source-directory-bucket-name");
     }
 }


### PR DESCRIPTION
*Description of changes:*

Fix the name of the s3Bucket field, which was previously incorrect. Add a test for that specific field.

*Target (OCI, Managed Runtime, both):*
unknown

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
