### PR TITLE
New version of aws-lambda-java-events

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ public class SqsHandler implements RequestHandler<SQSEvent, String> {
 <dependency>
  <groupId>com.amazonaws</groupId>
  <artifactId>aws-lambda-java-events</artifactId>
- <version>3.13.0</version>
+ <version>3.14.0</version>
 </dependency>
 ```
 

--- a/aws-lambda-java-events/README.md
+++ b/aws-lambda-java-events/README.md
@@ -73,7 +73,7 @@
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.13.0</version>
+        <version>3.14.0</version>
     </dependency>
     ...
 </dependencies>

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### September 13, 2024
+`3.14.0`:
+- Fix name of s3Bucket field of Task class in S3BatchEventV2 ([#506](https://github.com/aws/aws-lambda-java-libs/pull/506))
+
 ### July 29, 2024
 `3.13.0`:
 - Add S3BatchEventV2 ([#496](https://github.com/aws/aws-lambda-java-libs/pull/496))

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-events</artifactId>
-    <version>3.13.0</version>
+    <version>3.14.0</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Events Library</name>

--- a/aws-lambda-java-tests/pom.xml
+++ b/aws-lambda-java-tests/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.13.0</version>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/samples/kinesis-firehose-event-handler/pom.xml
+++ b/samples/kinesis-firehose-event-handler/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.13.0</version>
+            <version>3.14.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
*Description of changes:*  Release new version of awa-lambda-java-events library

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
