### PR TITLE
Return empty messageAttributes map for SQSEvent

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SQSEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SQSEvent.java
@@ -6,6 +6,7 @@ package com.amazonaws.services.lambda.runtime.events;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -360,6 +361,9 @@ public class SQSEvent implements Serializable, Cloneable {
          * @return message attributes
          */
         public Map<String, MessageAttribute> getMessageAttributes() {
+            if (messageAttributes == null) {
+                return Collections.emptyMap();
+            }
             return messageAttributes;
         }
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

This change copies across the `getMessageAttributes` implementation from the SQS sdk. Return an empty list instead of `null` if no message attributes are available.

https://github.com/aws/aws-sdk-java/blob/3c367441d1c5d2f21e10d54cb4f2b308a8b00c59/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/model/Message.java#L684-L686 

*Target (OCI, Managed Runtime, both):*

both?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
