### PR TITLE
Fix CognitoUserPoolPreTokenGenerationEventV2 group override details to list

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CognitoUserPoolPreTokenGenerationEventV2.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CognitoUserPoolPreTokenGenerationEventV2.java
@@ -127,8 +127,8 @@ public class CognitoUserPoolPreTokenGenerationEventV2 extends CognitoUserPoolEve
     @Builder(setterPrefix = "with")
     @NoArgsConstructor
     public static class GroupOverrideDetails {
-        private Map<String, String> groupsToOverride;
-        private Map<String, String> iamRolesToOverride;
+        private String[] groupsToOverride;
+        private String[] iamRolesToOverride;
         private String preferredRole;
     }
 }

--- a/aws-lambda-java-tests/src/test/resources/cognito_user_pool_pre_token_generation_event_v2_with_response.json
+++ b/aws-lambda-java-tests/src/test/resources/cognito_user_pool_pre_token_generation_event_v2_with_response.json
@@ -1,0 +1,48 @@
+{
+    "version": "2",
+    "triggerSource": "TokenGeneration_Authentication",
+    "region": "us-east-1",
+    "userPoolId": "us-east-1_EXAMPLE",
+    "userName": "JaneDoe",
+    "callerContext": {
+        "awsSdkVersion": "aws-sdk-unknown-unknown",
+        "clientId": "1example23456789"
+    },
+    "request": {
+        "userAttributes": {
+            "string": "string"
+        },
+        "scopes": ["string", "string"],
+        "groupConfiguration": {
+            "groupsToOverride": ["string", "string"],
+            "iamRolesToOverride": ["string", "string"],
+            "preferredRole": "string"
+        },
+        "clientMetadata": {
+            "string": "string"
+        }
+    },
+    "response": {
+        "claimsAndScopeOverrideDetails": {
+            "idTokenGeneration": {
+                "claimsToAddOrOverride": {
+                    "string": ["accepted datatype"]
+                },
+                "claimsToSuppress": ["string", "string"]
+            },
+            "accessTokenGeneration": {
+                "claimsToAddOrOverride": {
+                    "string": ["accepted datatype"]
+                },
+                "claimsToSuppress": ["string", "string"],
+                "scopesToAdd": ["string", "string"],
+                "scopesToSuppress": ["string", "string"]
+            },
+            "groupOverrideDetails": {
+                "groupsToOverride": ["my_group", "string"],
+                "iamRolesToOverride": ["my_role", "string"],
+                "preferredRole": "string"
+            }
+        }
+    }
+}


### PR DESCRIPTION
*Issue #516*

*Description of changes:*
CognitoUserPoolPreTokenGenerationEventV2 -> GroupOverrideDetails Response should return list types for groupsToOverride and iamRolesToOverride even when I use V2 pre token generation, not Map<String, String>


**This PR is mostly for me to explain the issue and will probably not build because of missing bumping of model version as I don't know how to do that**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
