### PR TITLE
fix: update CognitoUserPoolPreTokenGenerationEventV2 response model

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ public class SqsHandler implements RequestHandler<SQSEvent, String> {
 <dependency>
  <groupId>com.amazonaws</groupId>
  <artifactId>aws-lambda-java-events</artifactId>
- <version>3.14.0</version>
+ <version>3.15.0</version>
 </dependency>
 ```
 

--- a/aws-lambda-java-events/README.md
+++ b/aws-lambda-java-events/README.md
@@ -31,6 +31,7 @@
 * `CognitoUserPoolPreAuthenticationEvent`
 * `CognitoUserPoolPreSignUpEvent`
 * `CognitoUserPoolPreTokenGenerationEvent`
+* `CognitoUserPoolPreTokenGenerationEventV2`
 * `CognitoUserPoolVerifyAuthChallengeResponseEvent`
 * `ConfigEvent`
 * `ConnectEvent`
@@ -73,7 +74,7 @@
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.14.0</version>
+        <version>3.15.0</version>
     </dependency>
     ...
 </dependencies>

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### January 31, 2025
+`3.15.0`:
+- Fix `CognitoUserPoolPreTokenGenerationEventV2` model ([#519](https://github.com/aws/aws-lambda-java-libs/pull/519))
+
 ### September 13, 2024
 `3.14.0`:
 - Fix name of s3Bucket field of Task class in S3BatchEventV2 ([#506](https://github.com/aws/aws-lambda-java-libs/pull/506))

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-events</artifactId>
-    <version>3.14.0</version>
+    <version>3.15.0</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Events Library</name>

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CognitoUserPoolPreTokenGenerationEventV2.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/CognitoUserPoolPreTokenGenerationEventV2.java
@@ -127,8 +127,8 @@ public class CognitoUserPoolPreTokenGenerationEventV2 extends CognitoUserPoolEve
     @Builder(setterPrefix = "with")
     @NoArgsConstructor
     public static class GroupOverrideDetails {
-        private Map<String, String> groupsToOverride;
-        private Map<String, String> iamRolesToOverride;
+        private String[] groupsToOverride;
+        private String[] iamRolesToOverride;
         private String preferredRole;
     }
 }

--- a/aws-lambda-java-tests/pom.xml
+++ b/aws-lambda-java-tests/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.14.0</version>
+            <version>3.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/aws-lambda-java-tests/src/test/java/com/amazonaws/services/lambda/runtime/tests/EventLoaderTest.java
+++ b/aws-lambda-java-tests/src/test/java/com/amazonaws/services/lambda/runtime/tests/EventLoaderTest.java
@@ -418,6 +418,17 @@ public class EventLoaderTest {
         CognitoUserPoolPreTokenGenerationEventV2.Request request = event.getRequest();
         String[] requestScopes = request.getScopes();
         assertThat("aws.cognito.signin.user.admin").isEqualTo(requestScopes[0]);
+
+        CognitoUserPoolPreTokenGenerationEventV2.Response response = event.getResponse();
+        String[] groupsToOverride = response.getClaimsAndScopeOverrideDetails().getGroupOverrideDetails().getGroupsToOverride();
+        String[] iamRolesToOverride = response.getClaimsAndScopeOverrideDetails().getGroupOverrideDetails().getIamRolesToOverride();
+        String preferredRole = response.getClaimsAndScopeOverrideDetails().getGroupOverrideDetails().getPreferredRole();
+
+        assertThat("group-99").isEqualTo(groupsToOverride[0]);
+        assertThat("group-98").isEqualTo(groupsToOverride[1]);
+        assertThat("arn:aws:iam::123456789012:role/sns_caller99").isEqualTo(iamRolesToOverride[0]);
+        assertThat("arn:aws:iam::123456789012:role/sns_caller98").isEqualTo(iamRolesToOverride[1]);
+        assertThat("arn:aws:iam::123456789012:role/sns_caller_99").isEqualTo(preferredRole);
     }
 
     @Test

--- a/aws-lambda-java-tests/src/test/resources/cognito_user_pool_pre_token_generation_event_v2.json
+++ b/aws-lambda-java-tests/src/test/resources/cognito_user_pool_pre_token_generation_event_v2.json
@@ -21,13 +21,19 @@
         "groupConfiguration": {
             "groupsToOverride": ["group-1", "group-2", "group-3"],
             "iamRolesToOverride": ["arn:aws:iam::123456789012:role/sns_caller1", "arn:aws:iam::123456789012:role/sns_caller2", "arn:aws:iam::123456789012:role/sns_caller3"],
-            "preferredRole": ["arn:aws:iam::123456789012:role/sns_caller"]
+            "preferredRole": "arn:aws:iam::123456789012:role/sns_caller"
         },
         "scopes": [
             "aws.cognito.signin.user.admin", "openid", "email", "phone"
         ]
     },
     "response": {
-        "claimsAndScopeOverrideDetails": []
+        "claimsAndScopeOverrideDetails": {
+            "groupOverrideDetails": {
+                "groupsToOverride": ["group-99", "group-98"],
+                "iamRolesToOverride": ["arn:aws:iam::123456789012:role/sns_caller99", "arn:aws:iam::123456789012:role/sns_caller98"],
+                "preferredRole": "arn:aws:iam::123456789012:role/sns_caller_99"
+            }
+        }
     }
 }

--- a/samples/custom-serialization/fastJson/HelloWorldFunction/pom.xml
+++ b/samples/custom-serialization/fastJson/HelloWorldFunction/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.14.0</version>
+            <version>3.15.0</version>
         </dependency>
 
         <dependency>

--- a/samples/custom-serialization/gson/HelloWorldFunction/pom.xml
+++ b/samples/custom-serialization/gson/HelloWorldFunction/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-lambda-java-events</artifactId>
-          <version>3.14.0</version>
+          <version>3.15.0</version>
         </dependency>
         <dependency>
           <groupId>com.google.code.gson</groupId>

--- a/samples/custom-serialization/moshi/HelloWorldFunction/pom.xml
+++ b/samples/custom-serialization/moshi/HelloWorldFunction/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.14.0</version>
+            <version>3.15.0</version>
         </dependency>
 
         <dependency>

--- a/samples/custom-serialization/request-stream-handler/HelloWorldFunction/pom.xml
+++ b/samples/custom-serialization/request-stream-handler/HelloWorldFunction/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-lambda-java-events</artifactId>
-          <version>3.14.0</version>
+          <version>3.15.0</version>
         </dependency>
         <dependency>
           <groupId>com.google.code.gson</groupId>

--- a/samples/kinesis-firehose-event-handler/pom.xml
+++ b/samples/kinesis-firehose-event-handler/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.14.0</version>
+            <version>3.15.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
*Issue #:*  #516 

*Description of changes:*
- Fix incorrect response model for `CognitoUserPoolPreTokenGenerationEventV2` to match the exprected contract from the [docs](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html#cognito-user-pools-lambda-trigger-syntax-pre-token-generation)
- Expose the fix as `v3.15.0` since it's a breaking change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
