### PR TITLE
Add Rotation Token for SecretsManager Rotation Event

### DIFF
--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,10 +1,8 @@
-### Feb 3, 2025
-`3.16.0`:
-- Add RotationToken to SecretsManagerRotationEvent ([#520](https://github.com/aws/aws-lambda-java-libs/pull/520))
-
 ### January 31, 2025
 `3.15.0`:
 - Fix `CognitoUserPoolPreTokenGenerationEventV2` model ([#519](https://github.com/aws/aws-lambda-java-libs/pull/519))
+- Add RotationToken to SecretsManagerRotationEvent ([#520](https://github.com/aws/aws-lambda-java-libs/pull/520))
+
 
 ### September 13, 2024
 `3.14.0`:

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### Feb 3, 2025
+`3.16.0`:
+- Add RotationToken to SecretsManagerRotationEvent ([#520](https://github.com/aws/aws-lambda-java-libs/pull/520))
+
 ### January 31, 2025
 `3.15.0`:
 - Fix `CognitoUserPoolPreTokenGenerationEventV2` model ([#519](https://github.com/aws/aws-lambda-java-libs/pull/519))

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SecretsManagerRotationEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SecretsManagerRotationEvent.java
@@ -35,5 +35,6 @@ public class SecretsManagerRotationEvent {
     private String step;
     private String secretId;
     private String clientRequestToken;
+    private String rotationToken;
 
 }

--- a/aws-lambda-java-serialization/src/main/java/com/amazonaws/services/lambda/runtime/serialization/events/mixins/SecretsManagerRotationEventMixin.java
+++ b/aws-lambda-java-serialization/src/main/java/com/amazonaws/services/lambda/runtime/serialization/events/mixins/SecretsManagerRotationEventMixin.java
@@ -21,4 +21,8 @@ public abstract class SecretsManagerRotationEventMixin {
     // needed because Jackson expects "clientRequestToken" instead of "ClientRequestToken"
     @JsonProperty("ClientRequestToken") abstract String getClientRequestToken();
     @JsonProperty("ClientRequestToken") abstract void setClientRequestToken(String clientRequestToken);
+
+    // needed because Jackson expects "rotationToken" instead of "RotationToken"
+    @JsonProperty("RotationToken") abstract String getRotationToken();
+    @JsonProperty("RotationToken") abstract void setRotationToken(String rotationToken);
 }

--- a/aws-lambda-java-tests/src/test/java/com/amazonaws/services/lambda/runtime/tests/EventLoaderTest.java
+++ b/aws-lambda-java-tests/src/test/java/com/amazonaws/services/lambda/runtime/tests/EventLoaderTest.java
@@ -369,7 +369,9 @@ public class EventLoaderTest {
         assertThat(event)
                 .returns("123e4567-e89b-12d3-a456-426614174000", from(SecretsManagerRotationEvent::getClientRequestToken))
                 .returns("arn:aws:secretsmanager:eu-central-1:123456789012:secret:/powertools/secretparam-xBPaJ5", from(SecretsManagerRotationEvent::getSecretId))
-                .returns("CreateSecret", from(SecretsManagerRotationEvent::getStep));
+                .returns("CreateSecret", from(SecretsManagerRotationEvent::getStep))
+                .returns("8a4cc1ac-82ea-47c7-bd9f-aeb370b1b6a6", from(SecretsManagerRotationEvent::getRotationToken));
+;
     }
 
     @Test

--- a/aws-lambda-java-tests/src/test/resources/secrets_rotation_event.json
+++ b/aws-lambda-java-tests/src/test/resources/secrets_rotation_event.json
@@ -1,5 +1,6 @@
 {
   "Step" : "CreateSecret",
   "SecretId" : "arn:aws:secretsmanager:eu-central-1:123456789012:secret:/powertools/secretparam-xBPaJ5",
-  "ClientRequestToken" : "123e4567-e89b-12d3-a456-426614174000"
+  "ClientRequestToken" : "123e4567-e89b-12d3-a456-426614174000",
+  "RotationToken": "8a4cc1ac-82ea-47c7-bd9f-aeb370b1b6a6"
 }


### PR DESCRIPTION
*Issue #, if available:* RotationToken was introduced to SecretsManager Rotation Event. 

*Description of changes:* Add RotationToken field to SecretsManager Rotation Event. 

*Target (OCI, Managed Runtime, both):* both


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
