### PR TITLE
Refactor the Main Function Into Three Main Blocks.

### DIFF
--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/AWSLambda.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/AWSLambda.java
@@ -213,7 +213,7 @@ public class AWSLambda {
     }
 
     public static void main(String[] args) throws Throwable {
-        try (LambdaContextLogger logger = initLogger()){
+        try (LambdaContextLogger logger = initLogger()) {
             LambdaRequestHandler lambdaRequestHandler = getLambdaRequestHandlerObject(args[0], logger);
             startRuntimeLoop(lambdaRequestHandler, logger);
 

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/logging/LambdaContextLogger.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/logging/LambdaContextLogger.java
@@ -7,11 +7,11 @@ package com.amazonaws.services.lambda.runtime.api.client.logging;
 
 import com.amazonaws.services.lambda.runtime.logging.LogFormat;
 import com.amazonaws.services.lambda.runtime.logging.LogLevel;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.Closeable;
 import java.io.IOException;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
-public class LambdaContextLogger extends AbstractLambdaLogger implements Closeable{
+public class LambdaContextLogger extends AbstractLambdaLogger implements Closeable {
     // If a null string is passed in, replace it with "null",
     // replicating the behavior of System.out.println(null);
     private static final byte[] NULL_BYTES_VALUE = "null".getBytes(UTF_8);


### PR DESCRIPTION
*Description of changes:* Refactor the Main Function Into Three Main Blocks. Mainly 2 Inits and the Runtime Loop.

*Target (OCI, Managed Runtime, both):* Both


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
