### PR TITLE
fix: use PROFILER_STOP_COMMAND in Shutdown hook

### DIFF
--- a/experimental/aws-lambda-java-profiler/extension/src/main/java/com/amazonaws/services/lambda/extension/PreMain.java
+++ b/experimental/aws-lambda-java-profiler/extension/src/main/java/com/amazonaws/services/lambda/extension/PreMain.java
@@ -28,7 +28,7 @@ public class PreMain {
         if(!createFileIfNotExist("/tmp/aws-lambda-java-profiler")) {
             Logger.debug("starting the profiler for coldstart");
             startProfiler();
-            registerShutdownHook(AsyncProfiler.getInstance());
+            registerShutdownHook();
             try {
                 Integer port = Integer.parseInt(INTERNAL_COMMUNICATION_PORT);
                 Logger.debug("using profile communication port = " + port);
@@ -101,9 +101,9 @@ public class PreMain {
         }
     }
 
-    public static void registerShutdownHook(AsyncProfiler profiler) {
+    public static void registerShutdownHook() {
         Logger.debug("registering shutdown hook");
-        Thread shutdownHook = new Thread(new ShutdownHook(profiler));
+        Thread shutdownHook = new Thread(new ShutdownHook(PROFILER_STOP_COMMAND));
         Runtime.getRuntime().addShutdownHook(shutdownHook);
     }
 

--- a/experimental/aws-lambda-java-profiler/extension/src/main/java/com/amazonaws/services/lambda/extension/ShutdownHook.java
+++ b/experimental/aws-lambda-java-profiler/extension/src/main/java/com/amazonaws/services/lambda/extension/ShutdownHook.java
@@ -6,10 +6,10 @@ import one.profiler.AsyncProfiler;
 
 public class ShutdownHook implements Runnable {
 
-    private AsyncProfiler profiler;
+    private String stopCommand;
 
-    public ShutdownHook(AsyncProfiler profiler) {
-        this.profiler = profiler;
+    public ShutdownHook(String stopCommand) {
+        this.stopCommand = stopCommand;
     }
 
     @Override
@@ -18,7 +18,7 @@ public class ShutdownHook implements Runnable {
         try {
             final String fileName = "/tmp/profiling-data-shutdown.html";
             Logger.debug("stopping the profiler");
-            AsyncProfiler.getInstance().execute(String.format("stop,file=%s,include=*AWSLambda.main,include=start_thread", fileName));
+            AsyncProfiler.getInstance().execute(String.format(this.stopCommand, fileName));
         } catch (Exception e) {
             Logger.error("could not stop the profiler");
         }


### PR DESCRIPTION
*Issue #, if available:*
fixes: https://github.com/aws/aws-lambda-java-libs/issues/536

*Description of changes:*
Respect PROFILER_STOP_COMMAND in Shutdown hook

*Target (OCI, Managed Runtime, both):*
both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
