### PR TITLE
Add tenant id to lambda context and structured log messages

### DIFF
--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/EventHandlerLoader.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/EventHandlerLoader.java
@@ -581,6 +581,7 @@ public final class EventHandlerLoader {
                         cognitoIdentity,
                         LambdaEnvironment.FUNCTION_VERSION,
                         request.getInvokedFunctionArn(),
+                        request.getTenantId(),
                         clientContext
                 );
 

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/api/LambdaContext.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/api/LambdaContext.java
@@ -22,6 +22,7 @@ public class LambdaContext implements Context {
     private final long deadlineTimeInMs;
     private final CognitoIdentity cognitoIdentity;
     private final ClientContext clientContext;
+    private final String tenantId;
     private final LambdaLogger logger;
 
     public LambdaContext(
@@ -34,6 +35,7 @@ public class LambdaContext implements Context {
             CognitoIdentity identity,
             String functionVersion,
             String invokedFunctionArn,
+            String tenantId,
             ClientContext clientContext
     ) {
         this.memoryLimit = memoryLimit;
@@ -46,6 +48,7 @@ public class LambdaContext implements Context {
         this.clientContext = clientContext;
         this.functionVersion = functionVersion;
         this.invokedFunctionArn = invokedFunctionArn;
+        this.tenantId = tenantId;
         this.logger = com.amazonaws.services.lambda.runtime.LambdaRuntime.getLogger();
     }
 
@@ -89,6 +92,10 @@ public class LambdaContext implements Context {
         long now = System.currentTimeMillis();
         int delta = (int) (this.deadlineTimeInMs - now);
         return delta > 0 ? delta : 0;
+    }
+
+    public String getTenantId() {
+        return tenantId;
     }
 
     public LambdaLogger getLogger() {

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/logging/JsonLogFormatter.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/logging/JsonLogFormatter.java
@@ -41,6 +41,7 @@ public class JsonLogFormatter implements LogFormatter {
 
         if (lambdaContext != null) {
             msg.AWSRequestId = lambdaContext.getAwsRequestId();
+            msg.tenantId = lambdaContext.getTenantId();
         }
         return msg;
     }

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/logging/StructuredLogMessage.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/logging/StructuredLogMessage.java
@@ -12,4 +12,5 @@ class StructuredLogMessage {
     public String message;
     public LogLevel level;
     public String AWSRequestId;
+    public String tenantId;
 }

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/dto/InvocationRequest.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/dto/InvocationRequest.java
@@ -40,6 +40,11 @@ public class InvocationRequest {
      */
     private String cognitoIdentity;
 
+    /**
+     * The tenant ID associated with the request.
+     */
+    private String tenantId;
+
     private byte[] content;
 
     public String getId() {
@@ -92,6 +97,14 @@ public class InvocationRequest {
     @SuppressWarnings("unused")
     public void setCognitoIdentity(String cognitoIdentity) {
         this.cognitoIdentity = cognitoIdentity;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
     }
 
     public byte[] getContent() {

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/com_amazonaws_services_lambda_runtime_api_client_runtimeapi_NativeClient.cpp
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/com_amazonaws_services_lambda_runtime_api_client_runtimeapi_NativeClient.cpp
@@ -20,6 +20,7 @@ static jfieldID contentField;
 static jfieldID clientContextField;
 static jfieldID cognitoIdentityField;
 static jfieldID xrayTraceIdField;
+static jfieldID tenantIdField;
 
 
 jint JNI_OnLoad(JavaVM* vm, void* reserved) {
@@ -41,6 +42,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     xrayTraceIdField = env->GetFieldID(invocationRequestClass , "xrayTraceId", "Ljava/lang/String;");
     clientContextField = env->GetFieldID(invocationRequestClass , "clientContext", "Ljava/lang/String;");
     cognitoIdentityField = env->GetFieldID(invocationRequestClass , "cognitoIdentity", "Ljava/lang/String;");
+    tenantIdField = env->GetFieldID(invocationRequestClass, "tenantId", "Ljava/lang/String;");
 
     return JNI_VERSION;
 }
@@ -104,6 +106,10 @@ JNIEXPORT jobject JNICALL Java_com_amazonaws_services_lambda_runtime_api_client_
 
   if(response.cognito_identity != ""){
     CHECK_EXCEPTION(env, env->SetObjectField(invocationRequest, cognitoIdentityField, env->NewStringUTF(response.cognito_identity.c_str())));
+  }
+
+  if(response.tenant_id != ""){
+    CHECK_EXCEPTION(env, env->SetObjectField(invocationRequest, tenantIdField, env->NewStringUTF(response.tenant_id.c_str())));
   }
 
   bytes = reinterpret_cast<const jbyte*>(response.payload.c_str());

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/deps/aws-lambda-cpp-0.2.7/include/aws/lambda-runtime/runtime.h
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/deps/aws-lambda-cpp-0.2.7/include/aws/lambda-runtime/runtime.h
@@ -62,6 +62,11 @@ struct invocation_request {
     std::chrono::time_point<std::chrono::system_clock> deadline;
 
     /**
+     * Tenant ID of the current invocation.
+     */
+    std::string tenant_id;
+
+    /**
      * The number of milliseconds left before lambda terminates the current execution.
      */
     inline std::chrono::milliseconds get_time_remaining() const;

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/deps/aws-lambda-cpp-0.2.7/src/runtime.cpp
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/deps/aws-lambda-cpp-0.2.7/src/runtime.cpp
@@ -40,6 +40,7 @@ static constexpr auto CLIENT_CONTEXT_HEADER = "lambda-runtime-client-context";
 static constexpr auto COGNITO_IDENTITY_HEADER = "lambda-runtime-cognito-identity";
 static constexpr auto DEADLINE_MS_HEADER = "lambda-runtime-deadline-ms";
 static constexpr auto FUNCTION_ARN_HEADER = "lambda-runtime-invoked-function-arn";
+static constexpr auto TENANT_ID_HEADER = "lambda-runtime-aws-tenant-id";
 
 enum Endpoints {
     INIT,
@@ -300,6 +301,10 @@ runtime::next_outcome runtime::get_next()
             "Received payload: %s\nTime remaining: %" PRId64,
             req.payload.c_str(),
             static_cast<int64_t>(req.get_time_remaining().count()));
+    }
+
+    if (resp.has_header(TENANT_ID_HEADER)) {
+        req.tenant_id = resp.get_header(TENANT_ID_HEADER);
     }
     return next_outcome(req);
 }

--- a/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/api/LambdaContextTest.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/api/LambdaContextTest.java
@@ -18,6 +18,7 @@ public class LambdaContextTest {
     private static final String INVOKED_FUNCTION_ARN = "invoked-function-arn";
     private static final LambdaClientContext CLIENT_CONTEXT = new LambdaClientContext();
     public static final int MEMORY_LIMIT = 128;
+    public static final String TENANT_ID = "tenant-id";
 
     @Test
     public void getRemainingTimeInMillis() {
@@ -54,6 +55,6 @@ public class LambdaContextTest {
 
     private LambdaContext createContextWithDeadline(long deadlineTimeInMs) {
         return new LambdaContext(MEMORY_LIMIT, deadlineTimeInMs, REQUEST_ID, LOG_GROUP_NAME, LOG_STREAM_NAME,
-                FUNCTION_NAME, IDENTITY, FUNCTION_VERSION, INVOKED_FUNCTION_ARN, CLIENT_CONTEXT);
+                FUNCTION_NAME, IDENTITY, FUNCTION_VERSION, INVOKED_FUNCTION_ARN, TENANT_ID, CLIENT_CONTEXT);
     }
 }

--- a/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/logging/JsonLogFormatterTest.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/logging/JsonLogFormatterTest.java
@@ -29,6 +29,25 @@ public class JsonLogFormatterTest {
                 null,
                 null,
                 "function-arn",
+                null,
+                null
+        );
+        assertFormatsString("test log", LogLevel.WARN, context);
+    }
+
+    @Test
+    void testFormattingWithTenantIdInLambdaContext() {
+        LambdaContext context = new LambdaContext(
+                0,
+                0,
+                "request-id",
+                null,
+                null,
+                "function-name",
+                null,
+                null,
+                "function-arn",
+                "tenant-id",
                 null
         );
         assertFormatsString("test log", LogLevel.WARN, context);
@@ -52,6 +71,7 @@ public class JsonLogFormatterTest {
 
         if (context != null) {
             assertEquals(context.getAwsRequestId(), result.AWSRequestId);
+            assertEquals(context.getTenantId(), result.tenantId);
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add tenant id to LambdaContext object and structured log messages 

*Target (OCI, Managed Runtime, both):*
- Both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
