### PR TITLE
Fix EventHandlerLoaderTest failing after PojoSerializerLoaderTest

### DIFF
--- a/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/PojoSerializerLoaderTest.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/PojoSerializerLoaderTest.java
@@ -7,6 +7,7 @@ package com.amazonaws.services.lambda.runtime.api.client;
 
 import com.amazonaws.services.lambda.runtime.CustomPojoSerializer;
 import com.amazonaws.services.lambda.runtime.serialization.PojoSerializer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +32,7 @@ class PojoSerializerLoaderTest {
     @Mock
     private CustomPojoSerializer mockSerializer;
 
+    @AfterEach
     @BeforeEach
     void setUp() throws Exception {
         resetStaticFields();


### PR DESCRIPTION
*Issue #, if available:* EventHandlerLoaderTest fails when run after PojoSerializerLoaderTest.

*Description of changes:* EventHandlerLoaderTest fails when run after PojoSerializerLoaderTest. This was caused by not resetting static fields that were modified by the tests inPojoSerializerLoaderTest after the tests are done.

*Target (OCI, Managed Runtime, both):* both


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
