### PR TITLE
Adding Key/Value Schema metadata attributes for KafkaEvent

### DIFF
--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KafkaEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KafkaEvent.java
@@ -43,6 +43,8 @@ public class KafkaEvent {
         private String key;
         private String value;
         private List<Map<String, byte[]>> headers;
+        private SchemaMetadata keySchemaMetadata;
+        private SchemaMetadata valueSchemaMetadata;
     }
 
     @Data
@@ -58,5 +60,14 @@ public class KafkaEvent {
             //Kafka also uses '-' for toString()
             return topic + "-" + partition;
         }
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder(setterPrefix = "with")
+    public static class SchemaMetadata {
+        private String schemaId;
+        private String dataFormat;
     }
 }


### PR DESCRIPTION
As part of Schema Registry integration with Kafka Event Source Mapping (ESM), we are adding schema metadata attributes (schemaId and dataFormat) to the KafkaEvent object. These attributes will only be populated when Kafka ESM is integrated with Schema Registry. This enhancement maintains backward compatibility for existing users.