### PR TITLE
Bump aws-lambda-java-events version to 3.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ public class SqsHandler implements RequestHandler<SQSEvent, String> {
 <dependency>
  <groupId>com.amazonaws</groupId>
  <artifactId>aws-lambda-java-events</artifactId>
- <version>3.15.0</version>
+ <version>3.16.0</version>
 </dependency>
 ```
 

--- a/aws-lambda-java-events/README.md
+++ b/aws-lambda-java-events/README.md
@@ -74,7 +74,7 @@
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-lambda-java-events</artifactId>
-        <version>3.15.0</version>
+        <version>3.16.0</version>
     </dependency>
     ...
 </dependencies>

--- a/aws-lambda-java-events/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-events/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### June 17, 2025
+`3.16.0`:
+- Add Schema metadata related attributes in KafkaEvent ([#548](https://github.com/aws/aws-lambda-java-libs/pull/548))
+
 ### January 31, 2025
 `3.15.0`:
 - Fix `CognitoUserPoolPreTokenGenerationEventV2` model ([#519](https://github.com/aws/aws-lambda-java-libs/pull/519))

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-events</artifactId>
-    <version>3.15.0</version>
+    <version>3.16.0</version>
     <packaging>jar</packaging>
 
     <name>AWS Lambda Java Events Library</name>

--- a/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KafkaEvent.java
+++ b/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KafkaEvent.java
@@ -43,6 +43,8 @@ public class KafkaEvent {
         private String key;
         private String value;
         private List<Map<String, byte[]>> headers;
+        private SchemaMetadata keySchemaMetadata;
+        private SchemaMetadata valueSchemaMetadata;
     }
 
     @Data
@@ -58,5 +60,14 @@ public class KafkaEvent {
             //Kafka also uses '-' for toString()
             return topic + "-" + partition;
         }
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder(setterPrefix = "with")
+    public static class SchemaMetadata {
+        private String schemaId;
+        private String dataFormat;
     }
 }

--- a/aws-lambda-java-tests/pom.xml
+++ b/aws-lambda-java-tests/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/samples/custom-serialization/fastJson/HelloWorldFunction/pom.xml
+++ b/samples/custom-serialization/fastJson/HelloWorldFunction/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.16.0</version>
         </dependency>
 
         <dependency>

--- a/samples/custom-serialization/gson/HelloWorldFunction/pom.xml
+++ b/samples/custom-serialization/gson/HelloWorldFunction/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-lambda-java-events</artifactId>
-          <version>3.15.0</version>
+          <version>3.16.0</version>
         </dependency>
         <dependency>
           <groupId>com.google.code.gson</groupId>

--- a/samples/custom-serialization/moshi/HelloWorldFunction/pom.xml
+++ b/samples/custom-serialization/moshi/HelloWorldFunction/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.16.0</version>
         </dependency>
 
         <dependency>

--- a/samples/custom-serialization/request-stream-handler/HelloWorldFunction/pom.xml
+++ b/samples/custom-serialization/request-stream-handler/HelloWorldFunction/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-lambda-java-events</artifactId>
-          <version>3.15.0</version>
+          <version>3.16.0</version>
         </dependency>
         <dependency>
           <groupId>com.google.code.gson</groupId>

--- a/samples/kinesis-firehose-event-handler/pom.xml
+++ b/samples/kinesis-firehose-event-handler/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.16.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Bump aws-lambda-java-events version to 3.16.0**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
