### PR TITLE
Make Trace ID accessible through Context & aws-lambda-java-core version bump

### DIFF
--- a/.github/workflows/runtime-interface-client_pr.yml
+++ b/.github/workflows/runtime-interface-client_pr.yml
@@ -22,6 +22,10 @@ jobs:
       with:
         java-version: 8
         distribution: corretto
+    
+    - name: Build and install core dependency locally
+      working-directory: ./aws-lambda-java-core
+      run: mvn clean install
 
     - name: Build and install serialization dependency locally
       working-directory: ./aws-lambda-java-serialization
@@ -54,6 +58,10 @@ jobs:
 
     - name: Available buildx platforms
       run: echo ${{ steps.buildx.outputs.platforms }}
+    
+    - name: Build and install core dependency locally
+      working-directory: ./aws-lambda-java-core
+      run: mvn clean install
 
     - name: Build and install serialization dependency locally
       working-directory: ./aws-lambda-java-serialization

--- a/aws-lambda-java-core/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-core/RELEASE.CHANGELOG.md
@@ -1,3 +1,7 @@
+### September 3, 2025
+`1.4.0`
+- Getter support for x-ray trace ID through the Context object
+
 ### May 26, 2025
 `1.3.0`
 - Adding support for multi tenancy ([#545](https://github.com/aws/aws-lambda-java-libs/pull/545))

--- a/aws-lambda-java-core/pom.xml
+++ b/aws-lambda-java-core/pom.xml
@@ -5,7 +5,7 @@
   
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-core</artifactId>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <packaging>jar</packaging>
   
   <name>AWS Lambda Java Core Library</name>

--- a/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/Context.java
+++ b/aws-lambda-java-core/src/main/java/com/amazonaws/services/lambda/runtime/Context.java
@@ -109,4 +109,14 @@ public interface Context {
 	default String getTenantId() {
 		return null;
 	}
+
+	/**
+	 *
+	 * Returns the X-Ray trace ID associated with the request.
+	 *
+	 * @return null by default
+	 */
+	default String getXrayTraceId() {
+		return null;
+	}
 }

--- a/aws-lambda-java-runtime-interface-client/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/EventHandlerLoader.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/EventHandlerLoader.java
@@ -582,6 +582,7 @@ public final class EventHandlerLoader {
                         LambdaEnvironment.FUNCTION_VERSION,
                         request.getInvokedFunctionArn(),
                         request.getTenantId(),
+                        request.getXrayTraceId(),
                         clientContext
                 );
 

--- a/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/api/LambdaContext.java
+++ b/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/api/LambdaContext.java
@@ -23,6 +23,7 @@ public class LambdaContext implements Context {
     private final CognitoIdentity cognitoIdentity;
     private final ClientContext clientContext;
     private final String tenantId;
+    private final String xrayTraceId;
     private final LambdaLogger logger;
 
     public LambdaContext(
@@ -36,6 +37,7 @@ public class LambdaContext implements Context {
             String functionVersion,
             String invokedFunctionArn,
             String tenantId,
+            String xrayTraceId,
             ClientContext clientContext
     ) {
         this.memoryLimit = memoryLimit;
@@ -49,6 +51,7 @@ public class LambdaContext implements Context {
         this.functionVersion = functionVersion;
         this.invokedFunctionArn = invokedFunctionArn;
         this.tenantId = tenantId;
+        this.xrayTraceId = xrayTraceId;
         this.logger = com.amazonaws.services.lambda.runtime.LambdaRuntime.getLogger();
     }
 
@@ -96,6 +99,10 @@ public class LambdaContext implements Context {
 
     public String getTenantId() {
         return tenantId;
+    }
+
+    public String getXrayTraceId() {
+        return xrayTraceId;
     }
 
     public LambdaLogger getLogger() {

--- a/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/api/LambdaContextTest.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/api/LambdaContextTest.java
@@ -19,6 +19,7 @@ public class LambdaContextTest {
     private static final LambdaClientContext CLIENT_CONTEXT = new LambdaClientContext();
     public static final int MEMORY_LIMIT = 128;
     public static final String TENANT_ID = "tenant-id";
+    public static final String X_RAY_TRACE_ID = "x-ray-trace-id";
 
     @Test
     public void getRemainingTimeInMillis() {
@@ -55,6 +56,6 @@ public class LambdaContextTest {
 
     private LambdaContext createContextWithDeadline(long deadlineTimeInMs) {
         return new LambdaContext(MEMORY_LIMIT, deadlineTimeInMs, REQUEST_ID, LOG_GROUP_NAME, LOG_STREAM_NAME,
-                FUNCTION_NAME, IDENTITY, FUNCTION_VERSION, INVOKED_FUNCTION_ARN, TENANT_ID, CLIENT_CONTEXT);
+                FUNCTION_NAME, IDENTITY, FUNCTION_VERSION, INVOKED_FUNCTION_ARN, TENANT_ID, X_RAY_TRACE_ID, CLIENT_CONTEXT);
     }
 }

--- a/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/logging/JsonLogFormatterTest.java
+++ b/aws-lambda-java-runtime-interface-client/src/test/java/com/amazonaws/services/lambda/runtime/api/client/logging/JsonLogFormatterTest.java
@@ -30,6 +30,7 @@ public class JsonLogFormatterTest {
                 null,
                 "function-arn",
                 null,
+                null,
                 null
         );
         assertFormatsString("test log", LogLevel.WARN, context);
@@ -48,6 +49,7 @@ public class JsonLogFormatterTest {
                 null,
                 "function-arn",
                 "tenant-id",
+                "xray-trace-id",
                 null
         );
         assertFormatsString("test log", LogLevel.WARN, context);

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.alpine.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.alpine.yml
@@ -43,6 +43,7 @@ phases:
       # Install events (dependency of serialization)
       - (cd aws-lambda-java-events && mvn install)
       # Install serialization (dependency of RIC)
+      - (cd aws-lambda-java-core && mvn install)
       - (cd aws-lambda-java-serialization && mvn install)
       - (cd aws-lambda-java-runtime-interface-client && mvn install -DargLineForReflectionTestOnly="")
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazoncorretto.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazoncorretto.yml
@@ -42,6 +42,7 @@ phases:
       # Install events (dependency of serialization)
       - (cd aws-lambda-java-events && mvn install)
       # Install serialization (dependency of RIC)
+      - (cd aws-lambda-java-core && mvn install)
       - (cd aws-lambda-java-serialization && mvn install)
       - (cd aws-lambda-java-runtime-interface-client && mvn install -DargLineForReflectionTestOnly="")
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.1.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.1.yml
@@ -37,6 +37,7 @@ phases:
       # Install events (dependency of serialization)
       - (cd aws-lambda-java-events && mvn install)
       # Install serialization (dependency of RIC)
+      - (cd aws-lambda-java-core && mvn install)
       - (cd aws-lambda-java-serialization && mvn install)
       - (cd aws-lambda-java-runtime-interface-client && mvn install -DmultiArch=false -DargLineForReflectionTestOnly="")
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.2.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.2.yml
@@ -41,6 +41,7 @@ phases:
       # Install events (dependency of serialization)
       - (cd aws-lambda-java-events && mvn install)
       # Install serialization (dependency of RIC)
+      - (cd aws-lambda-java-core && mvn install)
       - (cd aws-lambda-java-serialization && mvn install)
       - (cd aws-lambda-java-runtime-interface-client && mvn install -DargLineForReflectionTestOnly="")
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.centos.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.centos.yml
@@ -41,6 +41,7 @@ phases:
       # Install events (dependency of serialization)
       - (cd aws-lambda-java-events && mvn install)
       # Install serialization (dependency of RIC)
+      - (cd aws-lambda-java-core && mvn install)
       - (cd aws-lambda-java-serialization && mvn install)
       - (cd aws-lambda-java-runtime-interface-client && mvn install)
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.debian.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.debian.yml
@@ -42,6 +42,7 @@ phases:
       # Install events (dependency of serialization)
       - (cd aws-lambda-java-events && mvn install)
       # Install serialization (dependency of RIC)
+      - (cd aws-lambda-java-core && mvn install)
       - (cd aws-lambda-java-serialization && mvn install)
       - (cd aws-lambda-java-runtime-interface-client && mvn install)
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.ubuntu.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.ubuntu.yml
@@ -44,6 +44,7 @@ phases:
       # Install events (dependency of serialization)
       - (cd aws-lambda-java-events && mvn install)
       # Install serialization (dependency of RIC)
+      - (cd aws-lambda-java-core && mvn install)
       - (cd aws-lambda-java-serialization && mvn install)
       - (cd aws-lambda-java-runtime-interface-client && mvn install)
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)


### PR DESCRIPTION
Make Trace ID accessible through Context & aws-lambda-java-core version bump to 1.4

*Issue #, if available:* https://github.com/aws/aws-lambda-java-libs/issues/562

*Description of changes:* Make Trace ID accessible through Context & aws-lambda-java-core version bump to 1.4

*Target (OCI, Managed Runtime, both):* Both


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
