### PR TITLE
test(log4j2): Add initial test suite covering plugin registration

### DIFF
--- a/aws-lambda-java-log4j2/pom.xml
+++ b/aws-lambda-java-log4j2/pom.xml
@@ -35,6 +35,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <log4j.version>2.25.4</log4j.version>
+        <junit-jupiter.version>5.12.2</junit-jupiter.version>
     </properties>
 
     <distributionManagement>
@@ -60,7 +61,29 @@
             <artifactId>log4j-api</artifactId>
             <version>${log4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>

--- a/aws-lambda-java-log4j2/src/test/java/com/amazonaws/services/lambda/runtime/log4j2/LambdaAppenderPluginTest.java
+++ b/aws-lambda-java-log4j2/src/test/java/com/amazonaws/services/lambda/runtime/log4j2/LambdaAppenderPluginTest.java
@@ -1,0 +1,86 @@
+/* Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+package com.amazonaws.services.lambda.runtime.log4j2;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LambdaAppenderPluginTest {
+
+    private final PrintStream originalOut = System.out;
+    private ByteArrayOutputStream captured;
+
+    @BeforeEach
+    void redirectStdout() throws UnsupportedEncodingException {
+        captured = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8.name()));
+    }
+
+    @AfterEach
+    void restoreStdout() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    void lambdaAppenderEmitsLogsAtVariousLevels() throws UnsupportedEncodingException {
+        Logger logger = LogManager.getLogger(LambdaAppenderPluginTest.class);
+
+        logger.debug("debug-msg");
+        logger.info("info-msg");
+        logger.warn("warn-msg");
+        logger.error("error-msg");
+
+        String output = captured.toString(StandardCharsets.UTF_8.name());
+
+        // The PatternLayout in src/test/resources/log4j2.xml is "%-5p %c{1} - %m%n",
+        // so each event should appear as "<LEVEL> LambdaAppenderPluginTest - <message>".
+        assertTrue(output.contains("DEBUG LambdaAppenderPluginTest - debug-msg"),
+                "expected DEBUG line in output but got:\n" + output);
+        assertTrue(output.contains("INFO  LambdaAppenderPluginTest - info-msg"),
+                "expected INFO line in output but got:\n" + output);
+        assertTrue(output.contains("WARN  LambdaAppenderPluginTest - warn-msg"),
+                "expected WARN line in output but got:\n" + output);
+        assertTrue(output.contains("ERROR LambdaAppenderPluginTest - error-msg"),
+                "expected ERROR line in output but got:\n" + output);
+
+        // Sanity check: log4j should not have fallen back to its default
+        // ConsoleAppender / status logger error message.
+        assertFalse(output.contains("ERROR StatusLogger"),
+                "log4j status logger reported an error, output was:\n" + output);
+    }
+
+    @Test
+    void lambdaAppenderEmitsJsonForJsonFormatLogger() throws UnsupportedEncodingException {
+        // The "json-test" logger is configured in src/test/resources/log4j2.xml
+        // with additivity=false to a second LambdaAppender using format="JSON"
+        // and JsonTemplateLayout backed by LambdaLayout.json.
+        Logger logger = LogManager.getLogger("json-test");
+
+        logger.info("json-info-msg");
+        logger.error("json-error-msg");
+
+        String output = captured.toString(StandardCharsets.UTF_8.name());
+
+        assertTrue(output.contains("json-info-msg"),
+                "expected json-info-msg in output but got:\n" + output);
+        assertTrue(output.contains("json-error-msg"),
+                "expected json-error-msg in output but got:\n" + output);
+
+        // Output should look like JSON, not the text PatternLayout from the
+        // root logger — so it must contain JSON field punctuation around the
+        // message rather than the "INFO  json-test - ..." text pattern.
+        assertTrue(output.contains("\"message\":\"json-info-msg\""),
+                "expected JSON-encoded message field but got:\n" + output);
+    }
+}

--- a/aws-lambda-java-log4j2/src/test/resources/log4j2.xml
+++ b/aws-lambda-java-log4j2/src/test/resources/log4j2.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Lambda name="LambdaText" format="TEXT">
+      <LambdaTextFormat>
+        <PatternLayout>
+          <pattern>%-5p %c{1} - %m%n</pattern>
+        </PatternLayout>
+      </LambdaTextFormat>
+    </Lambda>
+    <Lambda name="LambdaJson" format="JSON">
+      <LambdaJsonFormat>
+        <JsonTemplateLayout eventTemplateUri="classpath:LambdaLayout.json" />
+      </LambdaJsonFormat>
+    </Lambda>
+  </Appenders>
+  <Loggers>
+    <Logger name="json-test" level="DEBUG" additivity="false">
+      <AppenderRef ref="LambdaJson" />
+    </Logger>
+    <Root level="DEBUG">
+      <AppenderRef ref="LambdaText" />
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
This package previously had no tests and no JUnit dependency. Add JUnit Jupiter, the surefire plugin, and an initial test class that exercises the full plugin resolution path end-to-end: a log4j2.xml on the test classpath, a real LogManager-issued logger, and stdout capture (LambdaAppender writes through LambdaRuntime.getLogger() to System.out).

The TEXT test routes the root logger through LambdaTextFormat with a deterministic PatternLayout and asserts each level appears. The JSON test adds a second LambdaAppender with format="JSON" backed by JsonTemplateLayout + LambdaLayout.json, attached via additivity=false to a "json-test" logger, and asserts the messages show up JSON-encoded.

Add log4j-layout-template-json at test scope so the JSON path can resolve at test time. Users are still expected to bring their own copy at runtime (peer-dependency model, like PatternLayout); the published artifact's dependency surface is unchanged.

The tests succeed on Java 8 and fail on Java 25, because annotation processors are not run by default on Java 25, Log4j2Plugins.dat is not generated for our plugins, and both tests surface the resulting CLASS_NOT_FOUND from the log4j status logger.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
