### PR TITLE
build(log4j2): Pin compilation to JDK 8 via Maven Toolchains

### DIFF
--- a/aws-lambda-java-log4j2/pom.xml
+++ b/aws-lambda-java-log4j2/pom.xml
@@ -62,6 +62,32 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <toolchains>
+                        <jdk>
+                            <!-- Range matches both "8" (e.g. actions/setup-java)
+                                 and "1.8" (legacy / hand-written toolchains). -->
+                            <version>[1.8,9)</version>
+                        </jdk>
+                    </toolchains>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>dev</id>


### PR DESCRIPTION
Release 1.6.3 was built on a JDK that does not run annotation processors by default, which silently dropped the Log4j2 plugin descriptor (META-INF/.../Log4j2Plugins.dat) for LambdaAppender, LambdaTextFormat, and LambdaJsonFormat. The published artifact was broken at runtime: log4j could not resolve `<Lambda>`, `<LambdaTextFormat>`, or `<LambdaJsonFormat>` elements in user log4j2.xml configurations.

Configure maven-toolchains-plugin to require a JDK 8 toolchain so javac comes from a JDK that runs annotation processors by default, regardless of which JVM Maven is invoked under. The version range [1.8,9) matches both "1.8" and "8".

The existing GitHub Actions workflow at .github/workflows/aws-lambda-java-log4j2.yml uses actions/setup-java@v5 with java-version: 8 and distribution: corretto. setup-java@v5 auto-generates a ~/.m2/toolchains.xml entry with <version>8</version>, which the [1.8,9) range matches, so no workflow changes are required.

When no matching JDK 8 toolchain is available, the build now fails fast at the validate phase with a clear "Cannot find matching toolchain definitions" error instead of silently producing an artifact missing its plugin descriptor.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
