### PR TITLE
Pin compilation to JDK8 via Maven Toolchains

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,25 @@ To send us a pull request, please:
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
+
+## Build Prerequisites
+
+This project uses the Maven Toolchains Plugin to pin compilation to JDK 8. If you don't have a `~/.m2/toolchains.xml` configured, builds will fail with:
+
+```
+No toolchain found for type jdk [ version='[1.8,9)' ]
+```
+
+To fix this, copy the example file to your Maven config directory and update the path:
+
+```bash
+cp toolchains.xml.example ~/.m2/toolchains.xml
+```
+
+Then edit `~/.m2/toolchains.xml` and set `<jdkHome>` to your local JDK 8 installation path.
+
+Note: if you use `actions/setup-java` in CI (as our GitHub Actions workflows do), this file is generated automatically.
+
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and 
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 

--- a/aws-lambda-java-core/pom.xml
+++ b/aws-lambda-java-core/pom.xml
@@ -36,6 +36,32 @@
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <toolchains>
+            <jdk>
+              <!-- Range matches both "8" (e.g. actions/setup-java)
+                   and "1.8" (legacy / hand-written toolchains). -->
+              <version>[1.8,9)</version>
+            </jdk>
+          </toolchains>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>toolchain</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>dev</id>

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -80,6 +80,27 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <toolchains>
+            <jdk>
+              <!-- Range matches both "8" (e.g. actions/setup-java)
+                   and "1.8" (legacy / hand-written toolchains). -->
+              <version>[1.8,9)</version>
+            </jdk>
+          </toolchains>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>toolchain</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration>

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -42,6 +42,32 @@
         <junit-jupiter.version>5.12.2</junit-jupiter.version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <toolchains>
+                        <jdk>
+                            <!-- Range matches both "8" (e.g. actions/setup-java)
+                                 and "1.8" (legacy / hand-written toolchains). -->
+                            <version>[1.8,9)</version>
+                        </jdk>
+                    </toolchains>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <distributionManagement>
         <repository>
             <id>sonatype-nexus-staging</id>

--- a/aws-lambda-java-runtime-interface-client/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/pom.xml
@@ -116,6 +116,27 @@
         </extensions>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <toolchains>
+                        <jdk>
+                            <!-- Range matches both "8" (e.g. actions/setup-java)
+                                 and "1.8" (legacy / hand-written toolchains). -->
+                            <version>[1.8,9)</version>
+                        </jdk>
+                    </toolchains>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-install-plugin</artifactId>
                 <groupId>org.apache.maven.plugins</groupId>
                 <version>${maven-install-plugin.version}</version>

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/Dockerfile.agent
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/Dockerfile.agent
@@ -15,4 +15,17 @@ RUN mkdir /apache-maven && \
 
 # Declare JDK 8 in toolchains.xml so maven-toolchains-plugin can resolve it
 RUN mkdir -p /root/.m2 && \
-    printf '<?xml version="1.0" encoding="UTF-8"?>\n<toolchains>\n  <toolchain>\n    <type>jdk</type>\n    <provides>\n      <version>8</version>\n    </provides>\n    <configuration>\n      <jdkHome>/usr/lib/jvm/java-1.8.0-amazon-corretto</jdkHome>\n    </configuration>\n  </toolchain>\n</toolchains>\n' > /root/.m2/toolchains.xml
+    cat > /root/.m2/toolchains.xml <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<toolchains>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>8</version>
+    </provides>
+    <configuration>
+      <jdkHome>${JAVA_HOME}</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>
+EOF

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/Dockerfile.agent
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild-local/Dockerfile.agent
@@ -12,3 +12,7 @@ ENV PATH="$PATH:/apache-maven/bin"
 RUN mkdir /apache-maven && \
     curl https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz | \
     tar -xz -C /apache-maven --strip-components 1
+
+# Declare JDK 8 in toolchains.xml so maven-toolchains-plugin can resolve it
+RUN mkdir -p /root/.m2 && \
+    printf '<?xml version="1.0" encoding="UTF-8"?>\n<toolchains>\n  <toolchain>\n    <type>jdk</type>\n    <provides>\n      <version>8</version>\n    </provides>\n    <configuration>\n      <jdkHome>/usr/lib/jvm/java-1.8.0-amazon-corretto</jdkHome>\n    </configuration>\n  </toolchain>\n</toolchains>\n' > /root/.m2/toolchains.xml

--- a/aws-lambda-java-serialization/pom.xml
+++ b/aws-lambda-java-serialization/pom.xml
@@ -193,6 +193,27 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <toolchains>
+                        <jdk>
+                            <!-- Range matches both "8" (e.g. actions/setup-java)
+                                 and "1.8" (legacy / hand-written toolchains). -->
+                            <version>[1.8,9)</version>
+                        </jdk>
+                    </toolchains>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.1</version>
                 <executions>

--- a/aws-lambda-java-tests/pom.xml
+++ b/aws-lambda-java-tests/pom.xml
@@ -247,6 +247,27 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <toolchains>
+                        <jdk>
+                            <!-- Range matches both "8" (e.g. actions/setup-java)
+                                 and "1.8" (legacy / hand-written toolchains). -->
+                            <version>[1.8,9)</version>
+                        </jdk>
+                    </toolchains>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>

--- a/toolchains.xml.example
+++ b/toolchains.xml.example
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven Toolchains configuration for aws-lambda-java-libs.
+
+  This file tells Maven where to find JDK 8, which is required by the
+  maven-toolchains-plugin configured in each module's pom.xml.
+
+  To use: copy this file to ~/.m2/toolchains.xml and set the jdkHome
+  path to match your local JDK 8 installation.
+-->
+<toolchains>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>8</version>
+    </provides>
+    <configuration>
+      <jdkHome>/path/to/your/jdk8</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add maven-toolchains-plugin to all packages requiring JDK [1.8,9). Builds now fail fast if no matching JDK 8 toolchain is configured, preventing silent issues like missing annotation processor output when building with higher JDKs.

*Target (OCI, Managed Runtime, both):* both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
