### PR TITLE
Fix log4j2 integration test deploy

### DIFF
--- a/.github/workflows/run-integration-test.yml
+++ b/.github/workflows/run-integration-test.yml
@@ -101,6 +101,24 @@ jobs:
             --s3-bucket "${{ secrets.S3_BUCKET_LOG4J2_INTEG_TEST }}" \
             --capabilities CAPABILITY_IAM \
             2>&1 | tee /tmp/sam-deploy.log | tail -n 20
+
+          # Verify stack is in a healthy state
+          STACK_STATUS=$(aws cloudformation describe-stacks \
+            --stack-name "${stackName}" \
+            --region "${AWS_REGION}" \
+            --query 'Stacks[0].StackStatus' \
+            --output text 2>&1)
+          echo "Stack status: $STACK_STATUS"
+          if [ "$STACK_STATUS" != "CREATE_COMPLETE" ] && [ "$STACK_STATUS" != "UPDATE_COMPLETE" ]; then
+            echo "FAIL: Stack is not in a healthy state (status: $STACK_STATUS)"
+            aws cloudformation describe-stack-events \
+              --stack-name "${stackName}" \
+              --region "${AWS_REGION}" \
+              --query 'StackEvents[?ResourceStatus==`CREATE_FAILED` || ResourceStatus==`UPDATE_FAILED`].[LogicalResourceId,ResourceStatusReason]' \
+              --output table 2>&1 || true
+            exit 1
+          fi
+
           LOG4J2_TEST_FUNCTION=$(sam list stack-outputs --stack-name "${stackName}" --output json | jq -r '.[] | select(.OutputKey=="Log4j2TestFunction") | .OutputValue')
           echo "LOG4J2_TEST_FUNCTION=$LOG4J2_TEST_FUNCTION" >> "$GITHUB_OUTPUT"
           echo "Function name: $LOG4J2_TEST_FUNCTION"

--- a/lambda-integration-tests/samconfig.toml
+++ b/lambda-integration-tests/samconfig.toml
@@ -12,7 +12,6 @@ lint = true
 [default.deploy.parameters]
 capabilities = "CAPABILITY_IAM"
 confirm_changeset = true
-resolve_s3 = true
 
 [default.sync.parameters]
 watch = true

--- a/lambda-integration-tests/template.yaml
+++ b/lambda-integration-tests/template.yaml
@@ -23,6 +23,7 @@ Resources:
     Metadata:
       BuildMethod: java21
     Properties:
+      FunctionName: !Sub "${AWS::StackName}-fn"
       CodeUri: log4j2-test-function/
       Handler: integ.Log4j2TestHandler::handleRequest
       Runtime: java21


### PR DESCRIPTION
*Description of changes:*
1. resolve_s3 conflict - 'samconfig.toml' had 'resolve_s3 = true' which conflicted with the '--s3-bucket' flag passed in the workflow.
2. explicit 'FunctionName' in the SAM template to avoid CloudFormation name truncation causing DELETE_FAILED on cleanup
3. stack status verification - after 'sam deploy' the workflow now checks that the stack is in 'CREATE_COMPLETE' or 'UPDATE_COMPLETE' before proceeding. If not, it logs the stack status and any failed resource events then exists 1. This prevents the cascading failure where a failed deploy leads to a confusing "env var is required" error in run-tests.sh. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
