### PR TITLE
fix: speed up CI

### DIFF
--- a/.github/workflows/runtime-interface-client_pr.yml
+++ b/.github/workflows/runtime-interface-client_pr.yml
@@ -46,7 +46,15 @@ jobs:
         IS_JAVA_8: true
 
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -57,16 +65,10 @@ jobs:
         distribution: corretto
         cache: maven
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       with:
         install: true
-
-    - name: Available buildx platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
 
     - name: Build and install core dependency locally
       working-directory: ./aws-lambda-java-core
@@ -76,16 +78,16 @@ jobs:
       working-directory: ./aws-lambda-java-serialization
       run: mvn clean install
 
-    - name: Test Runtime Interface Client xplatform build - Run 'build' target
+    - name: Test Runtime Interface Client build - Run 'build-${{ matrix.arch }}' target
       working-directory: ./aws-lambda-java-runtime-interface-client
-      run: make build
+      run: make build-${{ matrix.arch }}
       env:
         IS_JAVA_8: true
 
     - name: Save the built jar
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
-        name: aws-lambda-java-runtime-interface-client
+        name: aws-lambda-java-runtime-interface-client-${{ matrix.arch }}
         path: ./aws-lambda-java-runtime-interface-client/target/aws-lambda-java-runtime-interface-client-*.jar
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/runtime-interface-client_pr.yml
+++ b/.github/workflows/runtime-interface-client_pr.yml
@@ -20,7 +20,15 @@ permissions:
 jobs:
 
   smoke-test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -39,9 +47,9 @@ jobs:
       working-directory: ./aws-lambda-java-serialization
       run: mvn clean install
 
-    - name: Runtime Interface Client smoke tests - Run 'pr' target
+    - name: Runtime Interface Client smoke tests - Run 'pr-${{ matrix.arch }}' target
       working-directory: ./aws-lambda-java-runtime-interface-client
-      run: make pr
+      run: make pr-${{ matrix.arch }}
       env:
         IS_JAVA_8: true
 

--- a/.github/workflows/runtime-interface-client_pr.yml
+++ b/.github/workflows/runtime-interface-client_pr.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
 
-  smoke-test:
+  smoke-test-arch:
     strategy:
       fail-fast: true
       matrix:
@@ -29,6 +29,7 @@ jobs:
           - arch: aarch64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
+    name: "smoke-test (${{ matrix.arch }})"
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -53,7 +54,7 @@ jobs:
       env:
         IS_JAVA_8: true
 
-  build:
+  build-arch:
     strategy:
       fail-fast: true
       matrix:
@@ -63,6 +64,7 @@ jobs:
           - arch: aarch64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
+    name: "build (${{ matrix.arch }})"
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -103,3 +105,27 @@ jobs:
       uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  smoke-test:
+    needs: smoke-test-arch
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check smoke-test results
+        run: |
+          if [ "${{ needs.smoke-test-arch.result }}" != "success" ]; then
+            echo "Smoke tests failed on one or more architectures"
+            exit 1
+          fi
+
+  build:
+    needs: build-arch
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check build results
+        run: |
+          if [ "${{ needs.build-arch.result }}" != "success" ]; then
+            echo "Build failed on one or more architectures"
+            exit 1
+          fi

--- a/aws-lambda-java-runtime-interface-client/Makefile
+++ b/aws-lambda-java-runtime-interface-client/Makefile
@@ -50,10 +50,17 @@ dev: test
 pr: test test-smoke
 
 .PHONY: build
-build: 
-	mvn clean install $(EXTRA_LOAD_ARG)
+build: build-x86_64 build-aarch64
+
+.PHONY: build-x86_64
+build-x86_64:
+	mvn clean install -DmultiArch=false $(EXTRA_LOAD_ARG)
 	mvn install -P linux-x86_64 $(EXTRA_LOAD_ARG)
 	mvn install -P linux_musl-x86_64 $(EXTRA_LOAD_ARG)
+
+.PHONY: build-aarch64
+build-aarch64:
+	mvn clean install -DmultiArch=false $(EXTRA_LOAD_ARG)
 	mvn install -P linux-aarch64 $(EXTRA_LOAD_ARG)
 	mvn install -P linux_musl-aarch64 $(EXTRA_LOAD_ARG)
 

--- a/aws-lambda-java-runtime-interface-client/Makefile
+++ b/aws-lambda-java-runtime-interface-client/Makefile
@@ -30,11 +30,20 @@ setup-codebuild-agent:
 	 --build-arg ARCHITECTURE=$(ARCHITECTURE_ALIAS) \
 	  - < test/integration/codebuild-local/Dockerfile.agent
 
+# Smoke tests are split per-architecture so CI can run each set on a native
+# runner. Running the linux/arm64/v8 combos under QEMU on an x86_64 host makes
+# `mvn install` recompile curl for aarch64 emulated, which takes ~30 minutes.
 .PHONY: test-smoke
-test-smoke: setup-codebuild-agent
+test-smoke: test-smoke-x86_64 test-smoke-aarch64
+
+.PHONY: test-smoke-x86_64
+test-smoke-x86_64: setup-codebuild-agent
 	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.alpine.yml alpine 3.15 corretto11 linux/amd64
-	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.alpine.yml alpine 3.15 corretto11 linux/arm64/v8
 	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.amazoncorretto.yml amazoncorretto amazoncorretto 11 linux/amd64
+
+.PHONY: test-smoke-aarch64
+test-smoke-aarch64: setup-codebuild-agent
+	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.alpine.yml alpine 3.15 corretto11 linux/arm64/v8
 	CODEBUILD_IMAGE_TAG=codebuild-agent test/integration/codebuild-local/test_one.sh test/integration/codebuild/buildspec.os.amazoncorretto.yml amazoncorretto amazoncorretto 11 linux/arm64/v8
 
 .PHONY: test-integ
@@ -48,6 +57,13 @@ dev: test
 # Verifications to run before sending a pull request
 .PHONY: pr
 pr: test test-smoke
+
+# Per-architecture PR checks so CI can run each on a native runner (no QEMU).
+.PHONY: pr-x86_64
+pr-x86_64: test test-smoke-x86_64
+
+.PHONY: pr-aarch64
+pr-aarch64: test test-smoke-aarch64
 
 .PHONY: build
 build: build-x86_64 build-aarch64

--- a/aws-lambda-java-runtime-interface-client/src/main/jni/build-jni-lib.sh
+++ b/aws-lambda-java-runtime-interface-client/src/main/jni/build-jni-lib.sh
@@ -118,10 +118,17 @@ else
   declare -a ARCHITECTURES=("x86_64" "aarch_64")
   declare -a LIBC_IMPLS=("glibc" "musl")
 
+  # `arch` reports the host as `aarch64`, but we use Maven's classifier
+  # spelling `aarch_64` in ARCHITECTURES, so normalize before comparing.
+  host_arch=$(arch)
+  if [ "${host_arch}" == "aarch64" ]; then
+      host_arch="aarch_64"
+  fi
+
   for arch in "${ARCHITECTURES[@]}"; do
 
-      if [[ "${MULTI_ARCH}" != "true" ]] && [[ "$(arch)" != "${arch}" ]]; then
-          echo "multi arch build not requested and host arch is $(arch), so skipping ${arch}..."
+      if [[ "${MULTI_ARCH}" != "true" ]] && [[ "${host_arch}" != "${arch}" ]]; then
+          echo "multi arch build not requested and host arch is ${host_arch}, so skipping ${arch}..."
           continue
       fi
 

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.alpine.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.alpine.yml
@@ -45,7 +45,7 @@ phases:
       # Install serialization (dependency of RIC)
       - (cd aws-lambda-java-core && mvn install)
       - (cd aws-lambda-java-serialization && mvn install)
-      - (cd aws-lambda-java-runtime-interface-client && mvn install -DargLineForReflectionTestOnly="")
+      - (cd aws-lambda-java-runtime-interface-client && mvn install -DmultiArch=false -DargLineForReflectionTestOnly="")
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)
       - export IMAGE_TAG="java-${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION}"
       - echo "Extracting and including Runtime Interface Emulator"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazoncorretto.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazoncorretto.yml
@@ -44,7 +44,7 @@ phases:
       # Install serialization (dependency of RIC)
       - (cd aws-lambda-java-core && mvn install)
       - (cd aws-lambda-java-serialization && mvn install)
-      - (cd aws-lambda-java-runtime-interface-client && mvn install -DargLineForReflectionTestOnly="")
+      - (cd aws-lambda-java-runtime-interface-client && mvn install -DmultiArch=false -DargLineForReflectionTestOnly="")
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)
       - export IMAGE_TAG="java-${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION}"
       - echo "Extracting and including Runtime Interface Emulator"


### PR DESCRIPTION
Speeds up the Runtime Interface Client (RIC) CI by running each architecture on a native GitHub runner instead of cross-building both architectures on a single x86_64 runner under QEMU emulation.

Previously the `build` and `smoke-test` jobs ran on `ubuntu-latest` and used QEMU to emulate `linux/arm64/v8`. Under emulation `mvn install` recompiles curl for aarch64, which took ~30 minutes. This PR splits the work per-architecture so the aarch64 half runs on a native ARM runner (`ubuntu-24.04-arm`), eliminating the emulation cost.

*Results:*

Measured on the RIC PR workflow (both jobs run in parallel, so the reported wall-clock is the longest job).

| Job | Before (QEMU, single x86_64 runner) | After (native runners) |
| --- | --- | --- |
| `build` | 44m 06s | x86_64: 5m 31s · aarch64: 4m 47s |
| `smoke-test` | 45m 51s | x86_64: 8m 55s · aarch64: 9m 24s |
| **Workflow wall-clock** | **~46 min** | **~13 min** |

Net gain: **~33 minutes faster (~71% reduction)** in end-to-end CI time. The bulk of the saving comes from `smoke-test`, which dropped from ~46 min to ~9 min (~37 min, ~80% faster) by eliminating the emulated aarch64 curl recompile.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
