### PR TITLE
Update Log4J version to fix CVE

### DIFF
--- a/aws-lambda-java-log4j2/README.md
+++ b/aws-lambda-java-log4j2/README.md
@@ -12,22 +12,22 @@ Example for Maven pom.xml
   <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-log4j2</artifactId>
-    <version>1.6.4</version>
+    <version>1.6.5</version>
   </dependency>
   <dependency>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-core</artifactId>
-    <version>2.25.4</version>
+    <version>2.25.5</version>
   </dependency>
   <dependency>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-api</artifactId>
-    <version>2.25.4</version>
+    <version>2.25.5</version>
   </dependency>
   <dependency>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-layout-template-json</artifactId>
-    <version>2.25.4</version>
+    <version>2.25.5</version>
   </dependency>
   ....
 </dependencies>
@@ -75,7 +75,7 @@ If you are using the [John Rengelman](https://github.com/johnrengelman/shadow) G
 
 dependencies{
   ...
-    implementation group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.6.4'
+    implementation group: 'com.amazonaws', name: 'aws-lambda-java-log4j2', version: '1.6.5'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: log4jVersion
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4jVersion
 }

--- a/aws-lambda-java-log4j2/RELEASE.CHANGELOG.md
+++ b/aws-lambda-java-log4j2/RELEASE.CHANGELOG.md
@@ -1,4 +1,7 @@
 ### May 19, 2026
+`1.6.5`:
+- Updated `log4j-core` and `log4j-api` dependencies to `2.25.5`
+
 `1.6.4`:
 - Fix regression in `1.6.3`
 

--- a/aws-lambda-java-log4j2/pom.xml
+++ b/aws-lambda-java-log4j2/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <log4j.version>2.25.4</log4j.version>
+        <log4j.version>2.25.5</log4j.version>
         <junit-jupiter.version>5.12.2</junit-jupiter.version>
     </properties>
 

--- a/lambda-integration-tests/log4j2-test-function/pom.xml
+++ b/lambda-integration-tests/log4j2-test-function/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <log4j.version>2.25.4</log4j.version>
+        <log4j.version>2.25.5</log4j.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
This version bump fixes a log corruption related CVE (https://nvd.nist.gov/vuln/detail/CVE-2026-49844)

*Target (OCI, Managed Runtime, both):*
Both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
