### PR TITLE
fix: speed up ci

### DIFF
--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.2.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.amazonlinux.2.yml
@@ -43,7 +43,7 @@ phases:
       # Install serialization (dependency of RIC)
       - (cd aws-lambda-java-core && mvn install)
       - (cd aws-lambda-java-serialization && mvn install)
-      - (cd aws-lambda-java-runtime-interface-client && mvn install -DargLineForReflectionTestOnly="")
+      - (cd aws-lambda-java-runtime-interface-client && mvn install -DmultiArch=false -DargLineForReflectionTestOnly="")
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)
       - export IMAGE_TAG="java-${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION}"
       - echo "Extracting and including Runtime Interface Emulator"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.debian.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.debian.yml
@@ -44,7 +44,7 @@ phases:
       # Install serialization (dependency of RIC)
       - (cd aws-lambda-java-core && mvn install)
       - (cd aws-lambda-java-serialization && mvn install)
-      - (cd aws-lambda-java-runtime-interface-client && mvn install -DargLineForReflectionTestOnly="")
+      - (cd aws-lambda-java-runtime-interface-client && mvn install -DmultiArch=false -DargLineForReflectionTestOnly="")
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)
       - export IMAGE_TAG="java-${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION}"
       - echo "Extracting and including Runtime Interface Emulator"

--- a/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.ubuntu.yml
+++ b/aws-lambda-java-runtime-interface-client/test/integration/codebuild/buildspec.os.ubuntu.yml
@@ -44,7 +44,7 @@ phases:
       # Install serialization (dependency of RIC)
       - (cd aws-lambda-java-core && mvn install)
       - (cd aws-lambda-java-serialization && mvn install)
-      - (cd aws-lambda-java-runtime-interface-client && mvn install -DargLineForReflectionTestOnly="")
+      - (cd aws-lambda-java-runtime-interface-client && mvn install -DmultiArch=false -DargLineForReflectionTestOnly="")
       - (cd aws-lambda-java-runtime-interface-client/test/integration/test-handler && mvn install)
       - export IMAGE_TAG="java-${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION}"
       - echo "Extracting and including Runtime Interface Emulator"


### PR DESCRIPTION
Follow-up on the integration tests. AL1, Amazon Corretto, and Alpine were already set to `-DmultiArch=false` since we now have a dedicated matrix job per architecture. This PR adds the same flag to the distributions where it was missing (AL2, Ubuntu, and Debian), roughly halving the integration test time for those distributions. No coverage is lost, as all architectures are still tested through the matrix.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
