### PR TITLE
ci: Caching Maven Dependencies

### DIFF
--- a/.github/workflows/release-runtime-interface-client.yml
+++ b/.github/workflows/release-runtime-interface-client.yml
@@ -75,6 +75,14 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       # Use the CodeBuild image's preinstalled Corretto 8. The image ships it at
       # $JAVA_8_HOME but defaults JAVA_HOME to Java 25, so point JAVA_HOME/PATH at
       # 8. Avoids actions/setup-java, which fetches from corretto.github.io +
@@ -163,6 +171,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0   # full history for tagging/pushing
+
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
       # Use the CodeBuild image's preinstalled Corretto 8. The image ships it at
       # $JAVA_8_HOME but defaults JAVA_HOME to Java 25, so point JAVA_HOME/PATH at

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,14 @@ jobs:
         with:
           fetch-depth: 0   # full history for tagging/pushing
 
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       # Use the CodeBuild image's preinstalled Corretto 8. The image ships it at
       # $JAVA_8_HOME but defaults JAVA_HOME to Java 25, so point JAVA_HOME/PATH at
       # 8. Avoids actions/setup-java, which fetches from corretto.github.io +


### PR DESCRIPTION
*Description of changes:*

Caching `maven` dependencies for `release` and `release-runtime-interface-client` to aviod throttling from Maven after we started doing matrix builds.

*Target (OCI, Managed Runtime, both):*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
