### PR TITLE
ci: Fix codecov project check on merge to main

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+# Codecov config. Coverage comes from the RIC package (JaCoCo), measured on x86_64 and aarch64.
+#
+# threshold 1%: PRs upload the union of both archs while merges to main can land a
+# single-arch report, so identical code can differ <1%. The tolerance avoids failing
+# merges on that measurement noise. patch is off; project coverage is the gate.
+# carryforward keeps a flag's last value when a commit doesn't re-upload it.
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch: off
+
+flag_management:
+  default_rules:
+    carryforward: true

--- a/.github/workflows/runtime-interface-client_merge_to_main.yml
+++ b/.github/workflows/runtime-interface-client_merge_to_main.yml
@@ -89,8 +89,57 @@ jobs:
         ENABLE_SNAPSHOT: ${{ secrets.ENABLE_SNAPSHOT }}
       run: make publish
 
+  # Coverage is measured on both native architectures (x86_64 and aarch64) so
+  # the coverage recorded for a merge to main matches what the PR build recorded
+  # (the union of both archs). Uploading a single x86_64 report here previously
+  # made every merge commit look ~0.4% lower than its own PR base, failing the
+  # codecov/project status on identical code.
+  coverage:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    name: "coverage (${{ matrix.arch }})"
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      with:
+        java-version: 8
+        distribution: corretto
+        cache: maven
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      with:
+        install: true
+
+    - name: Build and install core dependency locally
+      working-directory: ./aws-lambda-java-core
+      run: mvn clean install
+
+    - name: Build and install serialization dependency locally
+      working-directory: ./aws-lambda-java-serialization
+      run: mvn clean install
+
+    - name: Build Runtime Interface Client - Run 'build-${{ matrix.arch }}' target
+      working-directory: ./aws-lambda-java-runtime-interface-client
+      run: make build-${{ matrix.arch }}
+      env:
+        IS_JAVA_8: true
+
     - name: Upload coverage to Codecov
       if: env.CODECOV_TOKEN != null
       uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+      with:
+        files: ./aws-lambda-java-runtime-interface-client/target/site/jacoco/jacoco.xml
+        flags: ${{ matrix.arch }}
+        disable_search: true
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/runtime-interface-client_merge_to_main.yml
+++ b/.github/workflows/runtime-interface-client_merge_to_main.yml
@@ -95,6 +95,8 @@ jobs:
   # made every merge commit look ~0.4% lower than its own PR base, failing the
   # codecov/project status on identical code.
   coverage:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/runtime-interface-client_pr.yml
+++ b/.github/workflows/runtime-interface-client_pr.yml
@@ -99,6 +99,10 @@ jobs:
     - name: Upload coverage to Codecov
       if: env.CODECOV_TOKEN != null
       uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+      with:
+        files: ./aws-lambda-java-runtime-interface-client/target/site/jacoco/jacoco.xml
+        flags: ${{ matrix.arch }}
+        disable_search: true
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
### Problem
Some merges to main fail `codecov/project` even when the merged tree is unchanged. Last case (PR #629): "65.38% (-0.41%) compared to 7b484d3"  (a drop on a tree that is byte-for-byte identical to the PR branch tip).

### Root cause
PR builds upload coverage from two native matrix runners (x86_64 + aarch64), which Codecov merges into a union. Merge-to-main uploaded a single x86 report, so the merge commit measured slightly less coverage than its own base. With no `codecov.yml`, the default project status fails on any drop.

Codecov docs:
- https://docs.codecov.com/docs/merging-reports: "Codecov does not override report data for multiple uploads. We always merge the data."
- https://docs.codecov.com/docs/unexpected-coverage-changes, reason 2: "a different number of reports between head and base."

### Fix
**`.codecov.yml` (new):**
- `project.threshold: 1%`: tolerate sub-1% noise.
- `patch: off`: project coverage is the gate.
- `carryforward: true`: Codecov's recommended remedy for commits that don't re-upload every report (https://docs.codecov.com/docs/carryforward-flags).

**Workflows:**
- PR: tag each matrix upload with `flags: ${{ matrix.arch }}` + explicit JaCoCo path.
- Merge-to-main: add a two-arch `coverage` matrix job so main and PR record the same union of reports (also gives carryforward a real per-arch baseline).

### Result
Merges compare the union of both archs against a like-for-like base, so measurement noise no longer fails the build.

*Target (OCI, Managed Runtime, both):*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
