### PR TITLE
build: centralize module versions in a shared parent POM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,9 +167,9 @@ jobs:
 
       # Cross-module gate: serialization has no tests in its own build, so the
       # `mvn verify` above exercises nothing. Its behavioral coverage lives in
-      # aws-lambda-java-tests, which depends on serialization via a version
-      # property. Install the just-built serialization and run that suite
-      # against it, so we never publish serialization the suite hasn't exercised.
+      # aws-lambda-java-tests, which depends on it via the parent version map.
+      # Install the just-built serialization and run that suite against it, so
+      # we never publish serialization the suite hasn't exercised.
       - name: Run cross-module test gate
         run: |
           case "$MODULE" in
@@ -179,8 +179,10 @@ jobs:
               echo "::group::Installing $MODULE $MOD_VER for the gate"
               mvn install -DskipTests --file "$MODULE/pom.xml"
               echo "::endgroup::"
-              echo "::notice::Gating $MODULE on aws-lambda-java-tests (aws-lambda-java-serialization.version=$MOD_VER)"
-              mvn verify -Daws-lambda-java-serialization.version="$MOD_VER" --file aws-lambda-java-tests/pom.xml
+              echo "::notice::Gating $MODULE on aws-lambda-java-tests (lambda.serialization.version=$MOD_VER)"
+              # Override the map property so the suite runs against the
+              # just-built serialization, not the version pinned in the map.
+              mvn verify -Dlambda.serialization.version="$MOD_VER" --file aws-lambda-java-tests/pom.xml
               ;;
             *)
               echo "::notice::No cross-module test gate for $MODULE"
@@ -261,13 +263,15 @@ jobs:
             -Darguments="-gs $MAVEN_SETTINGS -Prelease -Dgpg.keyname=$GPG_KEYNAME -Dgpg.passphrase=$GPG_PASSPHRASE" \
             --file "$MODULE/pom.xml"
 
-      # Record the published version in the module's lastPublished comment so
-      # the POM reflects what's on Central. Rides in the version-bump PR below
-      # (main is protected).
-      - name: Record released version (POM lastPublished)
+      # Record the published version in the two places that track it, from the
+      # same EFFECTIVE_RELEASE_VERSION in one commit so they can't drift:
+      # (1) the module's lastPublished comment (informational, every module) and
+      # (2) the parent version map (functional, only for modules others depend
+      # on). Rides in the version-bump PR below (main is protected).
+      - name: Record released version (POM lastPublished + parent version map)
         if: ${{ github.event.inputs.skip_publish != 'true' }}
         run: |
-          # Module's lastPublished annotation.
+          # (1) Module's lastPublished annotation.
           if grep -q "<!-- lastPublished:" "$MODULE/pom.xml"; then
             sed -i "s|<!-- lastPublished:.*-->|<!-- lastPublished: ${EFFECTIVE_RELEASE_VERSION} (auto-updated by release.yml) -->|" "$MODULE/pom.xml"
             git add "$MODULE/pom.xml"
@@ -275,11 +279,22 @@ jobs:
             echo "::notice::$MODULE has no lastPublished comment; skipping annotation"
           fi
 
-          # Commit the record, or nothing if it didn't change.
+          # (2) Parent version map. Update the module's entry only if the parent declares one
+          PROP="lambda.${MODULE#aws-lambda-java-}.version"
+          if grep -qF "<${PROP}>" pom.xml; then
+            PROP_RE="${PROP//./\\.}"
+            sed -i.bak -E "s|(<${PROP_RE}>)[^<]*(</${PROP_RE}>)|\1${EFFECTIVE_RELEASE_VERSION}\2|" pom.xml
+            rm -f pom.xml.bak
+            git add pom.xml
+          else
+            echo "::notice::$MODULE is not consumed by other modules (no ${PROP} in parent POM); version map unchanged"
+          fi
+
+          # One commit for both records, or nothing if neither changed.
           if git diff --cached --quiet; then
             echo "::notice::$MODULE already recorded at ${EFFECTIVE_RELEASE_VERSION}; nothing to commit"
           else
-            git commit -m "chore(release): record ${MODULE} ${EFFECTIVE_RELEASE_VERSION} lastPublished"
+            git commit -m "chore(release): record ${MODULE} ${EFFECTIVE_RELEASE_VERSION} (lastPublished + version map)"
           fi
 
       # Prepend the changelog entry so it ships in the version-bump PR. Passed

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ experimental/aws-lambda-java-profiler/integration_tests/helloworld/bin
 .kiro
 build
 mise.toml
+
+# flatten-maven-plugin generates this self-contained POM at build time; it is
+# published in place of the raw module POM and must never be committed.
+.flattened-pom.xml

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,7 +32,8 @@ Releasable modules: `aws-lambda-java-core`, `aws-lambda-java-events`,
 2. Builds and tests the module.
 3. Publishes to Maven Central and pushes the tag `<module>-<version>`.
 4. Opens a **version-bump PR** into `main` with the next `-SNAPSHOT`, the updated
-   `lastPublished` comment, and your changelog entry.
+   `lastPublished` comment, the parent POM's version-map entry (for modules other
+   modules depend on: core, events, serialization), and your changelog entry.
 5. Creates a GitHub Release on the tag from your changelog entry.
 
 Merge the version-bump PR to return `main` to a clean `-SNAPSHOT` state.

--- a/aws-lambda-java-core/pom.xml
+++ b/aws-lambda-java-core/pom.xml
@@ -3,6 +3,13 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   
+  <parent>
+    <groupId>com.amazonaws</groupId>
+    <artifactId>aws-lambda-java-libs</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-lambda-java-core</artifactId>
   <version>1.4.1-SNAPSHOT</version>

--- a/aws-lambda-java-events-sdk-transformer/pom.xml
+++ b/aws-lambda-java-events-sdk-transformer/pom.xml
@@ -3,7 +3,13 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.amazonaws</groupId>
+  <parent>
+    <groupId>com.amazonaws</groupId>
+    <artifactId>aws-lambda-java-libs</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
   <artifactId>aws-lambda-java-events-sdk-transformer</artifactId>
   <version>3.1.2-SNAPSHOT</version>
   <!-- lastPublished: 3.1.1 (auto-updated by release.yml) -->
@@ -42,7 +48,6 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <sdk.v1.version>1.11.914</sdk.v1.version>
     <sdk.v2.version>2.15.40</sdk.v2.version>
-    <junit-jupiter.version>5.12.2</junit-jupiter.version>
     <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
   </properties>
 
@@ -69,14 +74,14 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-events</artifactId>
-      <version>3.16.1</version>
+      <!-- version managed by parent -->
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit-jupiter.version}</version>
+      <!-- version managed by parent -->
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/aws-lambda-java-events/pom.xml
+++ b/aws-lambda-java-events/pom.xml
@@ -3,6 +3,13 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-lambda-java-libs</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-events</artifactId>
     <version>3.16.2-SNAPSHOT</version>
@@ -43,7 +50,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jackson.version>2.20.1</jackson.version>
         <json.unit>2.40.1</json.unit>
-        <junit-jupiter.version>5.12.2</junit-jupiter.version>
     </properties>
 
     <build>
@@ -100,7 +106,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
+            <!-- version managed by parent -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/aws-lambda-java-log4j2/pom.xml
+++ b/aws-lambda-java-log4j2/pom.xml
@@ -1,7 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.amazonaws</groupId>
+    <parent>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-lambda-java-libs</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <artifactId>aws-lambda-java-log4j2</artifactId>
     <version>1.6.6-SNAPSHOT</version>
     <!-- lastPublished: 1.6.5 (auto-updated by release.yml) -->
@@ -37,7 +43,6 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <log4j.version>2.25.5</log4j.version>
-        <junit-jupiter.version>5.12.2</junit-jupiter.version>
     </properties>
 
     <distributionManagement>
@@ -51,7 +56,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.3</version>
+            <!-- version managed by parent (was 1.2.3) -->
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -72,7 +77,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
+            <!-- version managed by parent -->
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/aws-lambda-java-runtime-interface-client/pom.xml
+++ b/aws-lambda-java-runtime-interface-client/pom.xml
@@ -2,7 +2,14 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.amazonaws</groupId>
+
+    <parent>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-lambda-java-libs</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <artifactId>aws-lambda-java-runtime-interface-client</artifactId>
     <version>2.12.0-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -40,7 +47,9 @@
         <jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
         <maven-install-plugin.version>2.4</maven-install-plugin.version>
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
-        <junit-jupiter.version>5.12.2</junit-jupiter.version>
+        <!-- junit-jupiter.version inherited from parent; still referenced by the
+             surefire plugin dependency below, which dependencyManagement can't
+             manage (it only governs project dependencies, not plugin ones). -->
         <maven-checkstyle-plugin.version>3.4.0</maven-checkstyle-plugin.version>
         <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
         <!--
@@ -65,12 +74,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.4.0</version>
+            <!-- version managed by parent -->
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-serialization</artifactId>
-            <version>1.4.1</version>
+            <!-- version managed by parent -->
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -80,13 +89,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
+            <!-- version managed by parent -->
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${junit-jupiter.version}</version>
+            <!-- version managed by parent -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/aws-lambda-java-serialization/pom.xml
+++ b/aws-lambda-java-serialization/pom.xml
@@ -2,6 +2,13 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-lambda-java-libs</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-lambda-java-serialization</artifactId>
     <version>1.4.2-SNAPSHOT</version>

--- a/aws-lambda-java-tests/pom.xml
+++ b/aws-lambda-java-tests/pom.xml
@@ -3,7 +3,13 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.amazonaws</groupId>
+    <parent>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-lambda-java-libs</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <artifactId>aws-lambda-java-tests</artifactId>
     <version>1.1.3-SNAPSHOT</version>
     <!-- lastPublished: 1.1.2 (auto-updated by release.yml) -->
@@ -44,8 +50,7 @@
         -->
         <junit.version>5.9.2</junit.version>
         <jacoco.maven.plugin.version>0.8.7</jacoco.maven.plugin.version>
-        <aws-lambda-java-serialization.version>1.4.1</aws-lambda-java-serialization.version>
-        <aws-lambda-java-events.version>3.16.1</aws-lambda-java-events.version>
+        <!-- serialization / events versions come from the parent version map. -->
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <assertj-core.version>3.27.7</assertj-core.version>
     </properties>
@@ -54,12 +59,10 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-serialization</artifactId>
-            <version>${aws-lambda-java-serialization.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>${aws-lambda-java-events.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.amazonaws</groupId>
+    <artifactId>aws-lambda-java-libs</artifactId>
+    <!-- Non-SNAPSHOT so release:prepare accepts it; never published. -->
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <name>AWS Lambda Java Libs Parent</name>
+    <description>
+        Build-time-only parent that centralizes internal module versions.
+    </description>
+    <url>https://aws.amazon.com/lambda/</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://aws.amazon.com/apache2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <scm>
+        <url>https://github.com/aws/aws-lambda-java-libs.git</url>
+        <connection>scm:git:https://github.com/aws/aws-lambda-java-libs.git</connection>
+        <developerConnection>scm:git:https://github.com/aws/aws-lambda-java-libs.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+    <developers>
+        <developer>
+            <name>AWS Lambda team</name>
+            <organization>Amazon Web Services</organization>
+            <organizationUrl>https://aws.amazon.com/</organizationUrl>
+        </developer>
+    </developers>
+
+    <properties>
+        <lambda.core.version>1.4.0</lambda.core.version>
+        <lambda.events.version>3.16.1</lambda.events.version>
+        <lambda.serialization.version>1.4.1</lambda.serialization.version>
+        <junit-jupiter.version>5.12.2</junit-jupiter.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-lambda-java-core</artifactId>
+                <version>${lambda.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-lambda-java-events</artifactId>
+                <version>${lambda.events.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-lambda-java-serialization</artifactId>
+                <version>${lambda.serialization.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit-jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit-jupiter.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <!-- Flatten each child's POM: strip the parent and inline versions, so this
+         parent never needs publishing. -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <flattenMode>ossrh</flattenMode>
+                    <updatePomFile>true</updatePomFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Stacked on the release-workflow PR. Introduce a build-time-only parent POM that centralizes internal module versions and flattens each child's published POM, plus the wiring that depends on it:

- root pom.xml: version map (lambda.core/events/serialization.version), managed junit-jupiter, and the flatten-maven-plugin
- <parent> blocks in every module POM; internal + junit dependency versions now inherited instead of pinned per module
- release.yml: "Record released version" also updates the parent version map; cross-module gate overrides lambda.serialization.version
- RELEASING.md documents the version-map update; .gitignore ignores the generated .flattened-pom.xml

*Issue #, if available:*

*Description of changes:*

*Target (OCI, Managed Runtime, both):*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
